### PR TITLE
RDF-native catechism pipeline

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,51 @@
+name: compile-and-publish
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Recompile compiled.md for every submission
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for d in submissions/*/; do
+            slug=$(basename "$d")
+            if [ -f "$d/instance.ttl" ]; then
+              mgj compile "$slug"
+            fi
+          done
+
+      - name: Regenerate wiki
+        run: mgj wiki
+
+      - name: Commit refreshed artifacts (if any changed)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "$(git status --porcelain submissions/*/compiled.md wiki/)" ]; then
+            git config user.name "metagov-journal-bot"
+            git config user.email "bot@metagov.org"
+            git add submissions/*/compiled.md wiki/
+            git commit -m "auto-compile: refresh compiled.md and wiki"
+            git push
+          else
+            echo "no changes to commit"
+          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,57 @@
+name: validate
+
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Run pytest
+        run: pip install pytest && pytest -v
+
+      - name: SHACL-validate every submission
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for d in submissions/*/; do
+            slug=$(basename "$d")
+            if [ -f "$d/instance.ttl" ]; then
+              echo "::group::validate $slug"
+              mgj validate "$slug"
+              echo "::endgroup::"
+            fi
+          done
+
+      - name: Compile staleness check
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for d in submissions/*/; do
+            slug=$(basename "$d")
+            if [ -f "$d/instance.ttl" ]; then
+              mgj compile "$slug"
+            fi
+          done
+          mgj wiki
+          if ! git diff --exit-code -- submissions/*/compiled.md wiki/; then
+            echo "::error::compiled.md / wiki/ is stale — re-run mgj compile and mgj wiki and commit the result"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/
+venv/
+dist/
+build/
+
+# Submission caches
+submissions/*/.cache/
+
+# OS
+.DS_Store

--- a/ontology/mgj.ttl
+++ b/ontology/mgj.ttl
@@ -1,0 +1,732 @@
+# =============================================================================
+# Metagov Journal Ontology
+# Namespace: mgj
+# Version: 0.1.0
+#
+# Schema for the institutional catechism (Q1-Q9). Companion SHACL graphs
+# enforce minimum-documentation requirements.
+#
+# Design decisions:
+#   D1 — Submission and Institution are distinct entities. The institution
+#         persists; the submission is a versioned documentation artifact
+#         about it. Multiple submissions per institution are permitted.
+#   D2 — Per-question typed entities (Stakeholder, FieldSite, etc.) are
+#         first-class so the wiki can cross-link them. Each question also
+#         carries a narrative literal preserving the author's prose.
+#   D3 — foaf:Person and foaf:Organization are reused for agents.
+#         dcterms is reused for bibliographic metadata on References and
+#         on the Submission itself.
+#   D4 — Lessig modalities (Law/Norms/Markets/Architecture) and
+#         ConstitutionalElementType are SKOS controlled vocabularies.
+#         RoleType is an open SKOS scheme.
+#   D5 — Cardinality constraints are NOT expressed in OWL. They live in
+#         the companion SHACL graphs (per-question/q*.ttl, system.ttl).
+#   D6 — Authoring provenance is tracked on every triple via
+#         mgj:authorAffirmed (xsd:dateTime) for CLI-mediated edits and
+#         mgj:extractedBy (-> mgj:Extraction, prov:Activity) for parser
+#         output. Affirmed triples are sticky against re-extraction.
+#   D7 — UnresolvedAgent is a parser-output safety class for stakeholders
+#         too vague to map to foaf:Person/foaf:Organization. The author
+#         resolves these via CLI before affirmation.
+# =============================================================================
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+
+
+# =============================================================================
+# Ontology Declaration
+# =============================================================================
+
+<https://journal.metagov.org/ns/mgj>
+    a owl:Ontology ;
+    dcterms:title       "Metagov Journal Ontology" ;
+    dcterms:description "Schema for institutional catechism submissions to the Metagov Journal. Encodes the nine catechism questions as typed RDF entities suitable for SHACL validation, deterministic compilation, and cross-submission wiki generation." ;
+    owl:versionInfo     "0.1.0" .
+
+
+# =============================================================================
+# Core Catechism Classes
+# =============================================================================
+
+mgj:Institution
+    a owl:Class ;
+    rdfs:label   "Institution" ;
+    rdfs:comment "The persistent living institution being documented. Spans multiple submissions over time as the institution evolves. Identified by a stable IRI." .
+
+mgj:Submission
+    a owl:Class ;
+    rdfs:label   "Journal Submission" ;
+    rdfs:comment "A timestamped catechism response documenting one institution at one point in time. Carries DCTerms metadata, links to one mgj:Institution, and enumerates per-question narratives plus typed entity links." .
+
+mgj:Stakeholder
+    a owl:Class ;
+    rdfs:label   "Stakeholder" ;
+    rdfs:comment "An n-ary connector binding a foaf:Agent (Person or Organization), a Role, and the Institution. A given Person may appear as multiple Stakeholders across submissions, one per role. Maps to Q2." .
+
+mgj:FieldSite
+    a owl:Class ;
+    rdfs:label   "Field Site" ;
+    rdfs:comment "A specific instance where the institutional pattern can be observed — a deployment location, URL, or community venue. Maps to Q5." .
+
+mgj:EnvironmentalFactor
+    a owl:Class ;
+    rdfs:label   "Environmental Factor" ;
+    rdfs:comment "An external force (per Lessig: Law, Norms, Markets, or Architecture) that constrains or enables institutional patterns. Each instance is typed via mgj:lessigModality. Maps to Q3." .
+
+mgj:ConstitutionalElement
+    a owl:Class ;
+    rdfs:label   "Constitutional Element" ;
+    rdfs:comment "A formal or informal rule, norm, or procedure that generates institutional stability. Typed by mgj:elementType. Maps to Q4." .
+
+mgj:OriginEvent
+    a owl:Class ;
+    rdfs:subClassOf prov:Activity ;
+    rdfs:label   "Origin Event" ;
+    rdfs:comment "A founding event in the institution's history — convening, charter ratification, deployment, etc. Carries participants and a date. Maps to Q7." .
+
+mgj:EvolutionMechanism
+    a owl:Class ;
+    rdfs:label   "Evolution Mechanism" ;
+    rdfs:comment "A procedure or pattern by which the institution changes over time — formal amendment process, informal adaptation, response to external pressure. Maps to Q8." .
+
+mgj:Reference
+    a owl:Class ;
+    rdfs:label   "Reference" ;
+    rdfs:comment "A cited source supporting the documentation. Thin wrapper over DCTerms metadata (title, creator, date, identifier). Maps to Q9." .
+
+mgj:UnresolvedAgent
+    a owl:Class ;
+    rdfs:label   "Unresolved Agent" ;
+    rdfs:comment "Parser-output placeholder for an agent reference that could not be resolved to a foaf:Person or foaf:Organization (e.g. 'the community', 'research directors'). The author must resolve UnresolvedAgent instances via CLI commands before the relevant question can be affirmed. SHACL system shapes reject UnresolvedAgent in any affirmed graph." .
+
+mgj:LegalContext
+    a owl:Class ;
+    rdfs:label   "Legal Context" ;
+    rdfs:comment "Structural relationship between the documented institution and a host organization that provides legal, fiscal, or organizational standing — e.g. fiscal sponsor, legal parent, own incorporation. Distinct from Lessig's Law modality (which captures regulatory forces): a LegalContext is a named relation between two legal entities, not an environmental force. Bridges Q3 (environment), Q4 (constitution), and Q7 (origins). Optional — not every institution has a host. At most one per submission." .
+
+
+# =============================================================================
+# Provenance Classes (PROV-O extension)
+# =============================================================================
+
+mgj:Extraction
+    a owl:Class ;
+    rdfs:subClassOf prov:Activity ;
+    rdfs:label   "Extraction" ;
+    rdfs:comment "A parser invocation that produced one or more extracted triples. Records the model identifier, prompt hash, input.md SHA, and timestamp, enabling cache lookup and provenance audit." .
+
+
+# =============================================================================
+# SKOS Controlled Vocabularies
+# =============================================================================
+
+# --- Lessig modalities (closed scheme) ---
+
+mgj:LessigModalities
+    a skos:ConceptScheme ;
+    skos:prefLabel "Lessig Modalities" ;
+    rdfs:comment   "The four modalities of regulation per Lawrence Lessig (1998, 'The New Chicago School'): Law, Norms, Markets, Architecture. Used to type EnvironmentalFactors in Q3." .
+
+mgj:Law
+    a skos:Concept ;
+    skos:inScheme  mgj:LessigModalities ;
+    skos:prefLabel "Law" ;
+    skos:definition "Formal rules and regulations enforced by state authority." .
+
+mgj:Norms
+    a skos:Concept ;
+    skos:inScheme  mgj:LessigModalities ;
+    skos:prefLabel "Norms" ;
+    skos:definition "Social expectations, customs, and informal sanctions enforced by community." .
+
+mgj:Markets
+    a skos:Concept ;
+    skos:inScheme  mgj:LessigModalities ;
+    skos:prefLabel "Markets" ;
+    skos:definition "Economic forces, price signals, and incentive structures." .
+
+mgj:Architecture
+    a skos:Concept ;
+    skos:inScheme  mgj:LessigModalities ;
+    skos:prefLabel "Architecture" ;
+    skos:definition "Technical and physical infrastructure that constrains or enables behavior by design." .
+
+# --- Constitutional element types (closed scheme) ---
+
+mgj:ConstitutionalElementType
+    a skos:ConceptScheme ;
+    skos:prefLabel "Constitutional Element Type" ;
+    rdfs:comment   "Categories of constitutional elements distinguishing formal from informal mechanisms. Used to type ConstitutionalElements in Q4." .
+
+mgj:Bylaw
+    a skos:Concept ;
+    skos:inScheme  mgj:ConstitutionalElementType ;
+    skos:prefLabel "Bylaw" ;
+    skos:definition "A formally written rule (charter, bylaw, terms of service, smart contract clause)." .
+
+mgj:Norm
+    a skos:Concept ;
+    skos:inScheme  mgj:ConstitutionalElementType ;
+    skos:prefLabel "Norm" ;
+    skos:definition "An unwritten convention or expectation maintained by community practice." .
+
+mgj:DecisionProcedure
+    a skos:Concept ;
+    skos:inScheme  mgj:ConstitutionalElementType ;
+    skos:prefLabel "Decision Procedure" ;
+    skos:definition "A defined process by which the institution makes binding choices (voting, consensus, executive order)." .
+
+mgj:DisputeResolution
+    a skos:Concept ;
+    skos:inScheme  mgj:ConstitutionalElementType ;
+    skos:prefLabel "Dispute Resolution" ;
+    skos:definition "A defined process for resolving conflicts between participants." .
+
+mgj:AmendmentProcess
+    a skos:Concept ;
+    skos:inScheme  mgj:ConstitutionalElementType ;
+    skos:prefLabel "Amendment Process" ;
+    skos:definition "A defined process by which the institution's own rules can be modified." .
+
+# --- Role types (open scheme — extended per submission) ---
+
+mgj:RoleType
+    a skos:ConceptScheme ;
+    skos:prefLabel "Role Type" ;
+    rdfs:comment   "Open vocabulary of stakeholder roles. New role concepts are minted per submission and added to this scheme by CLI mediation; the SHACL system shape requires every Stakeholder's role to be in this scheme." .
+
+# --- Legal relationship types (closed scheme) ---
+
+mgj:LegalRelationshipType
+    a skos:ConceptScheme ;
+    skos:prefLabel "Legal Relationship Type" ;
+    rdfs:comment   "Closed vocabulary categorizing the structural relationship between an institution and its host organization. Used to type mgj:LegalContext." .
+
+mgj:FiscalSponsor
+    a skos:Concept ;
+    skos:inScheme  mgj:LegalRelationshipType ;
+    skos:prefLabel "Fiscal Sponsor" ;
+    skos:definition "Host organization receives charitable funds on the institution's behalf and disburses them per the host's policy. The institution is not itself a legal entity." .
+
+mgj:LegalIncorporation
+    a skos:Concept ;
+    skos:inScheme  mgj:LegalRelationshipType ;
+    skos:prefLabel "Legal Incorporation" ;
+    skos:definition "The institution is itself an incorporated legal entity (e.g. 501(c)(3) nonprofit, LLC, foundation, cooperative). The host organization slot identifies the registering entity (typically the institution itself)." .
+
+mgj:ParentOrganization
+    a skos:Concept ;
+    skos:inScheme  mgj:LegalRelationshipType ;
+    skos:prefLabel "Parent Organization" ;
+    skos:definition "The institution operates as a sub-unit, program, or division of a larger parent organization, sharing legal personhood with the parent." .
+
+mgj:Incubator
+    a skos:Concept ;
+    skos:inScheme  mgj:LegalRelationshipType ;
+    skos:prefLabel "Incubator" ;
+    skos:definition "Temporary host providing infrastructure, funding, or administrative support during early-stage development. Spinout to independent legal status is anticipated." .
+
+mgj:Network
+    a skos:Concept ;
+    skos:inScheme  mgj:LegalRelationshipType ;
+    skos:prefLabel "Network" ;
+    skos:definition "Member of a federation, alliance, or network of peer institutions without subordinate legal status. The host organization slot identifies the network." .
+
+
+# =============================================================================
+# Data Properties — Submission metadata
+# =============================================================================
+
+mgj:submissionDate
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:date ;
+    rdfs:label   "submission date" ;
+    rdfs:comment "ISO 8601 date on which this submission was authored." .
+
+mgj:submissionVersion
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "submission version" ;
+    rdfs:comment "Semantic version string for this submission (e.g. '1.0.0'). Increments on substantive revision." .
+
+
+# =============================================================================
+# Data Properties — Per-question narratives
+#
+# Each Qi has a corresponding narrative property carrying the author's prose.
+# The compiler renders narratives verbatim alongside the typed entity views.
+# =============================================================================
+
+mgj:q1Narrative
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "Q1 narrative (purpose)" ;
+    rdfs:comment "Author's prose answering Q1: what is the institution's purpose?" .
+
+mgj:q2Narrative
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "Q2 narrative (stakeholders)" ;
+    rdfs:comment "Author's prose answering Q2: who are the stakeholders and what are their roles?" .
+
+mgj:q3Narrative
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "Q3 narrative (environment)" ;
+    rdfs:comment "Author's prose answering Q3: what environmental factors shape the institution?" .
+
+mgj:q4Narrative
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "Q4 narrative (constitution)" ;
+    rdfs:comment "Author's prose answering Q4: what constitutes the institution's constitution?" .
+
+mgj:q5Narrative
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "Q5 narrative (field sites)" ;
+    rdfs:comment "Author's prose answering Q5: where are the field sites?" .
+
+mgj:q6Narrative
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "Q6 narrative (author relationship)" ;
+    rdfs:comment "Author's prose answering Q6: what is your relationship to the institution?" .
+
+mgj:q7Narrative
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "Q7 narrative (origins)" ;
+    rdfs:comment "Author's prose answering Q7: how and when did the institution emerge?" .
+
+mgj:q8Narrative
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "Q8 narrative (evolution)" ;
+    rdfs:comment "Author's prose answering Q8: how does the institution evolve?" .
+
+mgj:q9Narrative
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "Q9 narrative (references)" ;
+    rdfs:comment "Author's prose answering Q9: what references support this documentation?" .
+
+
+# =============================================================================
+# Data Properties — Institution
+# =============================================================================
+
+mgj:institutionName
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Institution ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "institution name" ;
+    rdfs:comment "Canonical human-readable name of the institution." .
+
+mgj:institutionDescription
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Institution ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "institution description" ;
+    rdfs:comment "Short description of the institution suitable for index pages and wiki summaries." .
+
+
+# =============================================================================
+# Data Properties — Stakeholder
+# =============================================================================
+
+mgj:roleLabel
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Stakeholder ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "role label" ;
+    rdfs:comment "Human-readable label for the stakeholder's role within the institution. Should match the prefLabel of a skos:Concept in mgj:RoleType." .
+
+mgj:stakeholderResponsibilities
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Stakeholder ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "responsibilities" ;
+    rdfs:comment "Description of what this stakeholder is responsible for within the institution." .
+
+
+# =============================================================================
+# Data Properties — FieldSite
+# =============================================================================
+
+mgj:fieldSiteLabel
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:FieldSite ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "field site label" ;
+    rdfs:comment "Human-readable name of the field site." .
+
+mgj:fieldSiteURL
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:FieldSite ;
+    rdfs:range   xsd:anyURI ;
+    rdfs:label   "field site URL" ;
+    rdfs:comment "Dereferenceable URL where the field site can be observed (forum, repository, address)." .
+
+mgj:fieldSiteDescription
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:FieldSite ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "field site description" ;
+    rdfs:comment "Description of what activity or attention is allocated at this site." .
+
+
+# =============================================================================
+# Data Properties — EnvironmentalFactor
+# =============================================================================
+
+mgj:factorDescription
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:EnvironmentalFactor ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "factor description" ;
+    rdfs:comment "Description of the environmental force and how it shapes the institution." .
+
+
+# =============================================================================
+# Data Properties — ConstitutionalElement
+# =============================================================================
+
+mgj:elementLabel
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:ConstitutionalElement ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "element label" ;
+    rdfs:comment "Short name for the constitutional element." .
+
+mgj:elementDescription
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:ConstitutionalElement ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "element description" ;
+    rdfs:comment "Description of the rule, norm, or procedure and how it operates." .
+
+mgj:elementSourceURL
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:ConstitutionalElement ;
+    rdfs:range   xsd:anyURI ;
+    rdfs:label   "element source URL" ;
+    rdfs:comment "Optional URL of the canonical written source for this element (charter document, repository file)." .
+
+
+# =============================================================================
+# Data Properties — OriginEvent
+# =============================================================================
+
+mgj:originLabel
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:OriginEvent ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "origin event label" ;
+    rdfs:comment "Short name for the founding event." .
+
+mgj:originDescription
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:OriginEvent ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "origin event description" ;
+    rdfs:comment "Description of what happened, who was involved, and what motivated the event." .
+
+mgj:originDate
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:OriginEvent ;
+    rdfs:range   xsd:date ;
+    rdfs:label   "origin date" ;
+    rdfs:comment "Date or approximate date the origin event occurred." .
+
+
+# =============================================================================
+# Data Properties — EvolutionMechanism
+# =============================================================================
+
+mgj:mechanismLabel
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:EvolutionMechanism ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "mechanism label" ;
+    rdfs:comment "Short name for the evolution mechanism." .
+
+mgj:mechanismDescription
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:EvolutionMechanism ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "mechanism description" ;
+    rdfs:comment "Description of how this mechanism produces institutional change." .
+
+
+# =============================================================================
+# Data Properties — Reference (uses dcterms primarily)
+# =============================================================================
+
+# References use dcterms:title, dcterms:creator, dcterms:date, dcterms:identifier
+# (DOI, URL, etc.) as their bibliographic metadata. No mgj-specific data
+# properties are introduced for this class.
+
+
+# =============================================================================
+# Data Properties — LegalContext
+# =============================================================================
+
+mgj:legalContextDescription
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:LegalContext ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "legal context description" ;
+    rdfs:comment "Narrative describing the host relationship — e.g. 'operates under Metagov's 501(c)(3) status; subject to Metagov's grant disbursement and IP policies'." .
+
+mgj:fundingReference
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:LegalContext ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "funding reference" ;
+    rdfs:comment "Optional grant number, contract ID, EIN, or other identifier associated with the legal context." .
+
+
+# =============================================================================
+# Data Properties — Author disclosure (Q6)
+# =============================================================================
+
+mgj:authorRole
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "author role" ;
+    rdfs:comment "The author's role(s) within the institution being documented. Q6 disclosure." .
+
+mgj:authorDisclosure
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "author disclosure" ;
+    rdfs:comment "Author's statement of biases, blind spots, conflicts of interest, and motivations for documenting this institution. Q6 disclosure." .
+
+
+# =============================================================================
+# Data Properties — UnresolvedAgent
+# =============================================================================
+
+mgj:unresolvedLabel
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:UnresolvedAgent ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "unresolved label" ;
+    rdfs:comment "The literal phrase the parser encountered (e.g. 'the community', 'research directors') that could not be resolved to a typed agent." .
+
+
+# =============================================================================
+# Data Properties — Provenance
+# =============================================================================
+
+mgj:authorAffirmed
+    a owl:DatatypeProperty ;
+    rdfs:range   xsd:dateTime ;
+    rdfs:label   "author affirmed" ;
+    rdfs:comment "Timestamp at which the author affirmed the subject triple via a CLI command. Affirmed triples are sticky against re-extraction: the parser cannot silently overwrite them." .
+
+mgj:extractionModel
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Extraction ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "extraction model" ;
+    rdfs:comment "Identifier of the language model used for extraction (e.g. 'claude-sonnet-4-6')." .
+
+mgj:promptHash
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Extraction ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "prompt hash" ;
+    rdfs:comment "SHA-256 of the prompt template used for this extraction. Pinned via the prompts/ directory." .
+
+mgj:inputHash
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Extraction ;
+    rdfs:range   xsd:string ;
+    rdfs:label   "input hash" ;
+    rdfs:comment "SHA-256 of the input.md slice (per-question section) that was extracted from." .
+
+mgj:extractedAt
+    a owl:DatatypeProperty ;
+    rdfs:domain  mgj:Extraction ;
+    rdfs:range   xsd:dateTime ;
+    rdfs:label   "extracted at" ;
+    rdfs:comment "Timestamp of extraction." .
+
+
+# =============================================================================
+# Object Properties — Submission top-level
+# =============================================================================
+
+mgj:documents
+    a owl:ObjectProperty ;
+    owl:inverseOf mgj:documentedBy ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   mgj:Institution ;
+    rdfs:label   "documents" ;
+    rdfs:comment "Links a Submission to the Institution it documents." .
+
+mgj:documentedBy
+    a owl:ObjectProperty ;
+    owl:inverseOf mgj:documents ;
+    rdfs:domain  mgj:Institution ;
+    rdfs:range   mgj:Submission ;
+    rdfs:label   "documented by" ;
+    rdfs:comment "Inverse: links an Institution to all submissions documenting it." .
+
+mgj:authoredBy
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   foaf:Person ;
+    rdfs:label   "authored by" ;
+    rdfs:comment "Links a Submission to its primary author. Q6 disclosure." .
+
+mgj:operatesUnder
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   mgj:LegalContext ;
+    rdfs:label   "operates under" ;
+    rdfs:comment "Links a Submission to a single LegalContext describing the institution's host relationship. Optional — institutions without a sponsor or parent omit this. At most one LegalContext per submission." .
+
+mgj:hostOrganization
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:LegalContext ;
+    rdfs:range   foaf:Organization ;
+    rdfs:label   "host organization" ;
+    rdfs:comment "The organization providing legal, fiscal, or organizational standing — fiscal sponsor, parent, network, or (for LegalIncorporation) the institution's own registering entity. Must resolve to an entry in shared/organizations.ttl." .
+
+mgj:legalRelationship
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:LegalContext ;
+    rdfs:range   skos:Concept ;
+    rdfs:label   "legal relationship" ;
+    rdfs:comment "Links a LegalContext to a concept in mgj:LegalRelationshipType (FiscalSponsor, LegalIncorporation, ParentOrganization, Incubator, Network)." .
+
+
+# =============================================================================
+# Object Properties — Per-question typed-entity links
+# =============================================================================
+
+# Q2 — Stakeholders
+mgj:hasStakeholder
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   mgj:Stakeholder ;
+    rdfs:label   "has stakeholder" ;
+    rdfs:comment "Links a Submission to its Stakeholder records. Q2." .
+
+mgj:stakeholderAgent
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Stakeholder ;
+    rdfs:range   foaf:Agent ;
+    rdfs:label   "stakeholder agent" ;
+    rdfs:comment "Links a Stakeholder n-ary node to the foaf:Agent (Person or Organization) playing the role. May also point to mgj:UnresolvedAgent during pre-affirmation states." .
+
+mgj:hasRole
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Stakeholder ;
+    rdfs:range   skos:Concept ;
+    rdfs:label   "has role" ;
+    rdfs:comment "Links a Stakeholder to a Role concept in the mgj:RoleType scheme." .
+
+# Q3 — Environmental factors
+mgj:hasEnvironmentalFactor
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   mgj:EnvironmentalFactor ;
+    rdfs:label   "has environmental factor" ;
+    rdfs:comment "Links a Submission to its EnvironmentalFactor records. Q3." .
+
+mgj:lessigModality
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:EnvironmentalFactor ;
+    rdfs:range   skos:Concept ;
+    rdfs:label   "Lessig modality" ;
+    rdfs:comment "Links an EnvironmentalFactor to a concept in the mgj:LessigModalities scheme (Law, Norms, Markets, or Architecture)." .
+
+# Q4 — Constitutional elements
+mgj:hasConstitutionalElement
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   mgj:ConstitutionalElement ;
+    rdfs:label   "has constitutional element" ;
+    rdfs:comment "Links a Submission to its ConstitutionalElement records. Q4." .
+
+mgj:elementType
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:ConstitutionalElement ;
+    rdfs:range   skos:Concept ;
+    rdfs:label   "element type" ;
+    rdfs:comment "Links a ConstitutionalElement to a concept in the mgj:ConstitutionalElementType scheme." .
+
+# Q5 — Field sites
+mgj:hasFieldSite
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   mgj:FieldSite ;
+    rdfs:label   "has field site" ;
+    rdfs:comment "Links a Submission to its FieldSite records. Q5." .
+
+# Q7 — Origin events
+mgj:hasOriginEvent
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   mgj:OriginEvent ;
+    rdfs:label   "has origin event" ;
+    rdfs:comment "Links a Submission to its OriginEvent records. Q7." .
+
+mgj:originParticipant
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:OriginEvent ;
+    rdfs:range   foaf:Agent ;
+    rdfs:label   "origin participant" ;
+    rdfs:comment "Links an OriginEvent to a participating agent (Person or Organization)." .
+
+# Q8 — Evolution mechanisms
+mgj:hasEvolutionMechanism
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   mgj:EvolutionMechanism ;
+    rdfs:label   "has evolution mechanism" ;
+    rdfs:comment "Links a Submission to its EvolutionMechanism records. Q8." .
+
+# Q9 — References
+mgj:hasReference
+    a owl:ObjectProperty ;
+    rdfs:domain  mgj:Submission ;
+    rdfs:range   mgj:Reference ;
+    rdfs:label   "has reference" ;
+    rdfs:comment "Links a Submission to its Reference records. Q9." .
+
+
+# =============================================================================
+# Object Properties — Provenance
+# =============================================================================
+
+mgj:extractedBy
+    a owl:ObjectProperty ;
+    rdfs:range   mgj:Extraction ;
+    rdfs:label   "extracted by" ;
+    rdfs:comment "Links a parser-emitted entity to the Extraction activity that produced it." .

--- a/ontology/shapes/per-question/q1-purpose.ttl
+++ b/ontology/shapes/per-question/q1-purpose.ttl
@@ -1,0 +1,29 @@
+# Q1 — Purpose: per-question SHACL shapes
+#
+# Inner-loop validation. Checks well-formedness of Q1 entities; minimum
+# cardinality on the Submission is enforced by system.ttl.
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+
+<https://journal.metagov.org/shapes/q1-purpose>
+    a owl:Ontology ;
+    dcterms:title   "Q1 Purpose Shapes" ;
+    owl:imports     <https://journal.metagov.org/ns/mgj> .
+
+
+mgj:Q1NarrativeShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Submission ;
+    sh:property [
+        sh:path      mgj:q1Narrative ;
+        sh:datatype  xsd:string ;
+        sh:minLength 1 ;
+        sh:maxCount  1 ;
+        sh:message   "Q1 narrative must be a non-empty string." ;
+    ] .

--- a/ontology/shapes/per-question/q2-stakeholders.ttl
+++ b/ontology/shapes/per-question/q2-stakeholders.ttl
@@ -1,0 +1,60 @@
+# Q2 — Stakeholders: per-question SHACL shapes
+#
+# Inner-loop validation: every Stakeholder must be well-formed (has an agent
+# and a role label). Cardinality (>=1 stakeholder per submission) and the
+# no-UnresolvedAgent rule live in system.ttl.
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+
+
+<https://journal.metagov.org/shapes/q2-stakeholders>
+    a owl:Ontology ;
+    dcterms:title   "Q2 Stakeholders Shapes" ;
+    owl:imports     <https://journal.metagov.org/ns/mgj> .
+
+
+mgj:Q2NarrativeShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Submission ;
+    sh:property [
+        sh:path      mgj:q2Narrative ;
+        sh:datatype  xsd:string ;
+        sh:minLength 1 ;
+        sh:maxCount  1 ;
+        sh:message   "Q2 narrative must be a non-empty string." ;
+    ] .
+
+
+mgj:StakeholderShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Stakeholder ;
+
+    sh:property [
+        sh:path     mgj:stakeholderAgent ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message  "Every Stakeholder must reference exactly one agent (foaf:Person, foaf:Organization, or mgj:UnresolvedAgent during pre-affirmation)." ;
+    ] ;
+
+    sh:property [
+        sh:path      mgj:roleLabel ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every Stakeholder must carry a role label." ;
+    ] ;
+
+    sh:property [
+        sh:path     mgj:hasRole ;
+        sh:maxCount 1 ;
+        sh:class    skos:Concept ;
+        sh:message  "If present, hasRole must point to a single skos:Concept (in mgj:RoleType scheme)." ;
+    ] .

--- a/ontology/shapes/per-question/q3-environment.ttl
+++ b/ontology/shapes/per-question/q3-environment.ttl
@@ -1,0 +1,49 @@
+# Q3 — Environmental factors: per-question SHACL shapes
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+
+
+<https://journal.metagov.org/shapes/q3-environment>
+    a owl:Ontology ;
+    dcterms:title   "Q3 Environmental Factors Shapes" ;
+    owl:imports     <https://journal.metagov.org/ns/mgj> .
+
+
+mgj:Q3NarrativeShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Submission ;
+    sh:property [
+        sh:path      mgj:q3Narrative ;
+        sh:datatype  xsd:string ;
+        sh:minLength 1 ;
+        sh:maxCount  1 ;
+        sh:message   "Q3 narrative must be a non-empty string." ;
+    ] .
+
+
+mgj:EnvironmentalFactorShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:EnvironmentalFactor ;
+
+    sh:property [
+        sh:path     mgj:lessigModality ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:in       ( mgj:Law mgj:Norms mgj:Markets mgj:Architecture ) ;
+        sh:message  "Every EnvironmentalFactor must be typed by exactly one Lessig modality (Law, Norms, Markets, Architecture)." ;
+    ] ;
+
+    sh:property [
+        sh:path      mgj:factorDescription ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every EnvironmentalFactor must have a description." ;
+    ] .

--- a/ontology/shapes/per-question/q4-constitution.ttl
+++ b/ontology/shapes/per-question/q4-constitution.ttl
@@ -1,0 +1,65 @@
+# Q4 — Constitution: per-question SHACL shapes
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+
+
+<https://journal.metagov.org/shapes/q4-constitution>
+    a owl:Ontology ;
+    dcterms:title   "Q4 Constitution Shapes" ;
+    owl:imports     <https://journal.metagov.org/ns/mgj> .
+
+
+mgj:Q4NarrativeShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Submission ;
+    sh:property [
+        sh:path      mgj:q4Narrative ;
+        sh:datatype  xsd:string ;
+        sh:minLength 1 ;
+        sh:maxCount  1 ;
+        sh:message   "Q4 narrative must be a non-empty string." ;
+    ] .
+
+
+mgj:ConstitutionalElementShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:ConstitutionalElement ;
+
+    sh:property [
+        sh:path      mgj:elementLabel ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every ConstitutionalElement must have a label." ;
+    ] ;
+
+    sh:property [
+        sh:path      mgj:elementDescription ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every ConstitutionalElement must have a description." ;
+    ] ;
+
+    sh:property [
+        sh:path     mgj:elementType ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:in       ( mgj:Bylaw mgj:Norm mgj:DecisionProcedure mgj:DisputeResolution mgj:AmendmentProcess ) ;
+        sh:message  "Every ConstitutionalElement must be typed by exactly one ConstitutionalElementType." ;
+    ] ;
+
+    sh:property [
+        sh:path     mgj:elementSourceURL ;
+        sh:datatype xsd:anyURI ;
+        sh:maxCount 1 ;
+        sh:message  "If present, elementSourceURL must be a single URI." ;
+    ] .

--- a/ontology/shapes/per-question/q5-fieldsites.ttl
+++ b/ontology/shapes/per-question/q5-fieldsites.ttl
@@ -1,0 +1,62 @@
+# Q5 — Field sites: per-question SHACL shapes
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+
+<https://journal.metagov.org/shapes/q5-fieldsites>
+    a owl:Ontology ;
+    dcterms:title   "Q5 Field Sites Shapes" ;
+    owl:imports     <https://journal.metagov.org/ns/mgj> .
+
+
+mgj:Q5NarrativeShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Submission ;
+    sh:property [
+        sh:path      mgj:q5Narrative ;
+        sh:datatype  xsd:string ;
+        sh:minLength 1 ;
+        sh:maxCount  1 ;
+        sh:message   "Q5 narrative must be a non-empty string." ;
+    ] .
+
+
+mgj:FieldSiteShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:FieldSite ;
+
+    sh:property [
+        sh:path      mgj:fieldSiteLabel ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every FieldSite must have a label." ;
+    ] ;
+
+    sh:property [
+        sh:path     mgj:fieldSiteURL ;
+        sh:datatype xsd:anyURI ;
+        sh:maxCount 1 ;
+        sh:message  "If present, fieldSiteURL must be a single URI." ;
+    ] ;
+
+    sh:property [
+        sh:path      mgj:fieldSiteDescription ;
+        sh:datatype  xsd:string ;
+        sh:maxCount  1 ;
+        sh:message   "If present, fieldSiteDescription must be a single literal." ;
+    ] ;
+
+    # Require at least one of URL or description so the site is identifiable.
+    sh:or (
+        [ sh:path mgj:fieldSiteURL ;         sh:minCount 1 ]
+        [ sh:path mgj:fieldSiteDescription ; sh:minCount 1 ]
+    ) ;
+
+    sh:message "Every FieldSite must have at least one of fieldSiteURL or fieldSiteDescription." .

--- a/ontology/shapes/per-question/q6-relationship.ttl
+++ b/ontology/shapes/per-question/q6-relationship.ttl
@@ -1,0 +1,47 @@
+# Q6 — Author relationship: per-question SHACL shapes
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+
+
+<https://journal.metagov.org/shapes/q6-relationship>
+    a owl:Ontology ;
+    dcterms:title   "Q6 Author Relationship Shapes" ;
+    owl:imports     <https://journal.metagov.org/ns/mgj> .
+
+
+mgj:Q6NarrativeShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Submission ;
+    sh:property [
+        sh:path      mgj:q6Narrative ;
+        sh:datatype  xsd:string ;
+        sh:minLength 1 ;
+        sh:maxCount  1 ;
+        sh:message   "Q6 narrative must be a non-empty string." ;
+    ] ;
+    sh:property [
+        sh:path      mgj:authorRole ;
+        sh:datatype  xsd:string ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "If present, authorRole must be a non-empty single literal." ;
+    ] ;
+    sh:property [
+        sh:path      mgj:authorDisclosure ;
+        sh:datatype  xsd:string ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "If present, authorDisclosure must be a non-empty single literal." ;
+    ] ;
+    sh:property [
+        sh:path     mgj:authoredBy ;
+        sh:maxCount 1 ;
+        sh:class    foaf:Person ;
+        sh:message  "If present, authoredBy must reference a single foaf:Person." ;
+    ] .

--- a/ontology/shapes/per-question/q7-origins.ttl
+++ b/ontology/shapes/per-question/q7-origins.ttl
@@ -1,0 +1,62 @@
+# Q7 — Origins: per-question SHACL shapes
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+
+<https://journal.metagov.org/shapes/q7-origins>
+    a owl:Ontology ;
+    dcterms:title   "Q7 Origins Shapes" ;
+    owl:imports     <https://journal.metagov.org/ns/mgj> .
+
+
+mgj:Q7NarrativeShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Submission ;
+    sh:property [
+        sh:path      mgj:q7Narrative ;
+        sh:datatype  xsd:string ;
+        sh:minLength 1 ;
+        sh:maxCount  1 ;
+        sh:message   "Q7 narrative must be a non-empty string." ;
+    ] .
+
+
+mgj:OriginEventShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:OriginEvent ;
+
+    sh:property [
+        sh:path      mgj:originLabel ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every OriginEvent must have a label." ;
+    ] ;
+
+    sh:property [
+        sh:path      mgj:originDescription ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every OriginEvent must have a description." ;
+    ] ;
+
+    sh:property [
+        sh:path     mgj:originDate ;
+        sh:datatype xsd:date ;
+        sh:maxCount 1 ;
+        sh:message  "If present, originDate must be a single xsd:date." ;
+    ] ;
+
+    sh:property [
+        sh:path     mgj:originParticipant ;
+        sh:minCount 1 ;
+        sh:message  "Every OriginEvent must reference at least one participant (foaf:Person or foaf:Organization)." ;
+    ] .

--- a/ontology/shapes/per-question/q8-evolution.ttl
+++ b/ontology/shapes/per-question/q8-evolution.ttl
@@ -1,0 +1,49 @@
+# Q8 — Evolution: per-question SHACL shapes
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+
+<https://journal.metagov.org/shapes/q8-evolution>
+    a owl:Ontology ;
+    dcterms:title   "Q8 Evolution Shapes" ;
+    owl:imports     <https://journal.metagov.org/ns/mgj> .
+
+
+mgj:Q8NarrativeShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Submission ;
+    sh:property [
+        sh:path      mgj:q8Narrative ;
+        sh:datatype  xsd:string ;
+        sh:minLength 1 ;
+        sh:maxCount  1 ;
+        sh:message   "Q8 narrative must be a non-empty string." ;
+    ] .
+
+
+mgj:EvolutionMechanismShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:EvolutionMechanism ;
+
+    sh:property [
+        sh:path      mgj:mechanismLabel ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every EvolutionMechanism must have a label." ;
+    ] ;
+
+    sh:property [
+        sh:path      mgj:mechanismDescription ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every EvolutionMechanism must have a description." ;
+    ] .

--- a/ontology/shapes/per-question/q9-references.ttl
+++ b/ontology/shapes/per-question/q9-references.ttl
@@ -1,0 +1,58 @@
+# Q9 — References: per-question SHACL shapes
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+
+<https://journal.metagov.org/shapes/q9-references>
+    a owl:Ontology ;
+    dcterms:title   "Q9 References Shapes" ;
+    owl:imports     <https://journal.metagov.org/ns/mgj> .
+
+
+mgj:Q9NarrativeShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Submission ;
+    sh:property [
+        sh:path      mgj:q9Narrative ;
+        sh:datatype  xsd:string ;
+        sh:minLength 1 ;
+        sh:maxCount  1 ;
+        sh:message   "Q9 narrative must be a non-empty string." ;
+    ] .
+
+
+mgj:ReferenceShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Reference ;
+
+    sh:property [
+        sh:path      dcterms:title ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every Reference must have a dcterms:title." ;
+    ] ;
+
+    sh:property [
+        sh:path      dcterms:identifier ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:message   "Every Reference must have a dcterms:identifier (DOI or canonical URL)." ;
+    ] ;
+
+    sh:property [
+        sh:path      dcterms:date ;
+        sh:maxCount  1 ;
+        sh:message   "If present, dcterms:date must be a single literal." ;
+    ] ;
+
+    sh:property [
+        sh:path      dcterms:creator ;
+        sh:message   "If present, dcterms:creator may be repeated (one or more authors)." ;
+    ] .

--- a/ontology/shapes/system.ttl
+++ b/ontology/shapes/system.ttl
@@ -1,0 +1,243 @@
+# =============================================================================
+# Metagov Journal — System-level SHACL Shapes
+#
+# Outer-loop validation. A submission must pass these shapes after all nine
+# inner-loop questions have been affirmed. Encodes:
+#   - Cardinality: every Qi has its required entities and narrative
+#   - Integrity: no UnresolvedAgent in the affirmed graph
+#   - Resolution: stakeholder agents resolve to foaf:Person or foaf:Organization
+#                 (not bare blank nodes); roles resolve to skos:Concepts
+#   - Submission metadata: institution, date, version, primary author
+# =============================================================================
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+
+
+<https://journal.metagov.org/shapes/system>
+    a owl:Ontology ;
+    dcterms:title       "Metagov Journal System SHACL Shapes" ;
+    dcterms:description "System-level constraints applied to a fully affirmed submission. Required for outer-loop validation, CI staleness checks, and merge gating." ;
+    owl:versionInfo     "0.1.0" ;
+    owl:imports         <https://journal.metagov.org/ns/mgj> .
+
+
+# =============================================================================
+# Submission — top-level required fields and per-Q cardinalities
+# =============================================================================
+
+mgj:SubmissionSystemShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Submission ;
+    rdfs:label "Submission System Shape" ;
+
+    # --- Submission metadata ---
+    sh:property [
+        sh:path     mgj:documents ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class    mgj:Institution ;
+        sh:message  "A Submission must document exactly one Institution." ;
+    ] ;
+    sh:property [
+        sh:path      mgj:submissionDate ;
+        sh:datatype  xsd:date ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:message   "A Submission must carry a submissionDate." ;
+    ] ;
+    sh:property [
+        sh:path      mgj:submissionVersion ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "A Submission must carry a submissionVersion." ;
+    ] ;
+
+    # --- Per-Q narratives (Q1..Q9 all required) ---
+    sh:property [ sh:path mgj:q1Narrative ; sh:minCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ; sh:message "Q1 narrative is required." ] ;
+    sh:property [ sh:path mgj:q2Narrative ; sh:minCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ; sh:message "Q2 narrative is required." ] ;
+    sh:property [ sh:path mgj:q3Narrative ; sh:minCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ; sh:message "Q3 narrative is required." ] ;
+    sh:property [ sh:path mgj:q4Narrative ; sh:minCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ; sh:message "Q4 narrative is required." ] ;
+    sh:property [ sh:path mgj:q5Narrative ; sh:minCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ; sh:message "Q5 narrative is required." ] ;
+    sh:property [ sh:path mgj:q6Narrative ; sh:minCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ; sh:message "Q6 narrative is required." ] ;
+    sh:property [ sh:path mgj:q7Narrative ; sh:minCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ; sh:message "Q7 narrative is required." ] ;
+    sh:property [ sh:path mgj:q8Narrative ; sh:minCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ; sh:message "Q8 narrative is required." ] ;
+    sh:property [ sh:path mgj:q9Narrative ; sh:minCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ; sh:message "Q9 narrative is required." ] ;
+
+    # --- Per-Q cardinality (typed entities) ---
+    sh:property [
+        sh:path     mgj:hasStakeholder ;
+        sh:minCount 1 ;
+        sh:class    mgj:Stakeholder ;
+        sh:message  "Q2: at least one Stakeholder is required." ;
+    ] ;
+    sh:property [
+        sh:path     mgj:hasEnvironmentalFactor ;
+        sh:minCount 1 ;
+        sh:class    mgj:EnvironmentalFactor ;
+        sh:message  "Q3: at least one EnvironmentalFactor is required." ;
+    ] ;
+    sh:property [
+        sh:path     mgj:hasConstitutionalElement ;
+        sh:minCount 1 ;
+        sh:class    mgj:ConstitutionalElement ;
+        sh:message  "Q4: at least one ConstitutionalElement is required." ;
+    ] ;
+    sh:property [
+        sh:path     mgj:hasFieldSite ;
+        sh:minCount 1 ;
+        sh:class    mgj:FieldSite ;
+        sh:message  "Q5: at least one FieldSite is required." ;
+    ] ;
+    sh:property [
+        sh:path     mgj:authoredBy ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class    foaf:Person ;
+        sh:message  "Q6: a primary author (foaf:Person) is required." ;
+    ] ;
+    sh:property [
+        sh:path      mgj:authorDisclosure ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Q6: an author disclosure statement is required." ;
+    ] ;
+    sh:property [
+        sh:path     mgj:hasOriginEvent ;
+        sh:minCount 1 ;
+        sh:class    mgj:OriginEvent ;
+        sh:message  "Q7: at least one OriginEvent is required." ;
+    ] ;
+    sh:property [
+        sh:path     mgj:hasEvolutionMechanism ;
+        sh:minCount 1 ;
+        sh:class    mgj:EvolutionMechanism ;
+        sh:message  "Q8: at least one EvolutionMechanism is required." ;
+    ] ;
+    sh:property [
+        sh:path     mgj:hasReference ;
+        sh:minCount 1 ;
+        sh:class    mgj:Reference ;
+        sh:message  "Q9: at least one Reference is required." ;
+    ] ;
+
+    # --- LegalContext (optional, at most one) ---
+    sh:property [
+        sh:path     mgj:operatesUnder ;
+        sh:maxCount 1 ;
+        sh:class    mgj:LegalContext ;
+        sh:message  "If present, operatesUnder must reference a single LegalContext." ;
+    ] .
+
+
+# =============================================================================
+# Institution — minimum identification
+# =============================================================================
+
+mgj:InstitutionSystemShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Institution ;
+
+    sh:property [
+        sh:path      mgj:institutionName ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Institution must have a name." ;
+    ] .
+
+
+# =============================================================================
+# Stakeholder — every agent must be resolved (no UnresolvedAgent in graph)
+# =============================================================================
+
+mgj:StakeholderSystemShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:Stakeholder ;
+
+    sh:property [
+        sh:path     mgj:stakeholderAgent ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        # Allow Person or Organization but reject UnresolvedAgent.
+        sh:not [ sh:class mgj:UnresolvedAgent ] ;
+        sh:message  "All Stakeholders must reference a resolved foaf:Agent (no mgj:UnresolvedAgent in affirmed graph)." ;
+    ] ;
+
+    sh:property [
+        sh:path     mgj:hasRole ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class    skos:Concept ;
+        sh:message  "All Stakeholders must reference a skos:Concept role at the system level." ;
+    ] .
+
+
+# =============================================================================
+# LegalContext — host org and relationship type required when present
+# =============================================================================
+
+mgj:LegalContextSystemShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:LegalContext ;
+
+    sh:property [
+        sh:path     mgj:hostOrganization ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class    foaf:Organization ;
+        sh:message  "Every LegalContext must reference exactly one hostOrganization (foaf:Organization in shared/organizations.ttl)." ;
+    ] ;
+
+    sh:property [
+        sh:path     mgj:legalRelationship ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:in       ( mgj:FiscalSponsor mgj:LegalIncorporation mgj:ParentOrganization mgj:Incubator mgj:Network ) ;
+        sh:message  "Every LegalContext must be typed by exactly one LegalRelationshipType concept." ;
+    ] ;
+
+    sh:property [
+        sh:path      mgj:legalContextDescription ;
+        sh:datatype  xsd:string ;
+        sh:minCount  1 ;
+        sh:maxCount  1 ;
+        sh:minLength 1 ;
+        sh:message   "Every LegalContext must have a description of the host relationship." ;
+    ] ;
+
+    sh:property [
+        sh:path      mgj:fundingReference ;
+        sh:datatype  xsd:string ;
+        sh:maxCount  1 ;
+        sh:message   "If present, fundingReference must be a single literal." ;
+    ] .
+
+
+# =============================================================================
+# No UnresolvedAgent allowed at the system level
+# =============================================================================
+
+mgj:NoUnresolvedAgentShape
+    a sh:NodeShape ;
+    sh:targetClass mgj:UnresolvedAgent ;
+    sh:property [
+        sh:path     rdf:type ;
+        sh:hasValue mgj:UnresolvedAgent ;
+        # By targeting UnresolvedAgent and asserting a violation, any presence
+        # of an UnresolvedAgent in the affirmed graph fails system validation.
+        sh:not [ sh:hasValue mgj:UnresolvedAgent ] ;
+        sh:message  "mgj:UnresolvedAgent instances must be resolved (replaced with a foaf:Person or foaf:Organization) before system validation." ;
+    ] .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mgj"
+version = "0.1.0"
+description = "Metagov Journal — RDF-native authoring, validation, and compilation tooling for the institutional catechism"
+readme = "readme.md"
+requires-python = ">=3.13"
+dependencies = [
+    "rdflib>=7.0.0",
+    "pyshacl>=0.25.0",
+    "pydantic>=2.0.0",
+    "typer>=0.12.0",
+    "rich>=13.0.0",
+    "anthropic>=0.40.0",
+]
+
+[project.scripts]
+mgj = "mgj.cli:app"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov>=5.0.0",
+    "mypy>=1.10.0",
+    "ruff>=0.4.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/mgj"]
+
+[tool.mypy]
+strict = true
+python_version = "3.13"
+mypy_path = "src"
+
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+src = ["src"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--tb=short"

--- a/scripts/build_self_submission.py
+++ b/scripts/build_self_submission.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""
+Build the self-referential `metagov-journal` submission via mgj CLI commands.
+
+This is the M7 end-to-end smoke test. It demonstrates the full pipeline
+without an LLM call: existing prose in submissions/metagov-journal/specification.md
+is preserved as input.md, and the structured RDF is constructed via direct
+CLI invocations (the same path the parser would write through after author
+confirmation in the inner loop).
+
+Idempotent: every step skips work it has already done. Re-runnable safely.
+
+Usage:
+    python scripts/build_self_submission.py
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SLUG = "metagov-journal"
+
+
+def run(args: list[str], allow_failure: bool = False) -> subprocess.CompletedProcess:
+    print(f"  $ mgj {' '.join(args)}")
+    result = subprocess.run(["mgj", *args], cwd=REPO, capture_output=True, text=True)
+    if result.returncode != 0 and not allow_failure:
+        print(result.stdout)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(result.returncode)
+    return result
+
+
+def step(name: str) -> None:
+    print(f"\n--- {name} ---")
+
+
+def main() -> None:
+    step("seed shared people registry")
+    for slug, name in [
+        ("michael-zargham", "Michael Zargham"),
+        ("joshua-tan", "Joshua Tan"),
+        ("seth-frey", "Seth Frey"),
+        ("ellie-rennie", "Ellie Rennie"),
+    ]:
+        run(["people", "add", slug, "--name", name], allow_failure=True)
+
+    step("seed shared organizations registry")
+    run(["orgs", "add", "metagov", "--name", "Metagov", "--homepage", "https://metagov.org"], allow_failure=True)
+
+    step("copy specification.md → input.md (preserve original prose)")
+    sub_dir = REPO / "submissions" / SLUG
+    spec = sub_dir / "specification.md"
+    input_md = sub_dir / "input.md"
+    if not input_md.exists():
+        if spec.exists():
+            shutil.copyfile(spec, input_md)
+            print(f"  copied {spec} → {input_md}")
+        else:
+            print(f"  [warn] no specification.md at {spec}; skipping")
+
+    step("init the submission scaffold (idempotent)")
+    run(["init", SLUG, "--name", "The Metagov Journal", "--version", "1.0.0", "--date", "2026-04-25"], allow_failure=True)
+
+    step("set narratives (Q1..Q9) — preserved author prose")
+    narratives = {
+        1: (
+            "The Metagov Journal produces and maintains a peer-reviewed commons of "
+            "institutional knowledge. Its stable pattern involves practitioners documenting "
+            "living institutions through structured catechisms, peers reviewing these "
+            "documentations for completeness and clarity, and the community accumulating "
+            "reusable organizational patterns. Success manifests as a growing repository of "
+            "institutional specifications that practitioners reference when designing new "
+            "organizations or evolving existing ones. The institution functions properly "
+            "when submissions flow regularly, reviews maintain quality standards, and "
+            "documented patterns get reused across contexts."
+        ),
+        2: (
+            "Authors document institutions they understand deeply, answering the catechism "
+            "and providing supporting materials. Reviewers evaluate submissions for "
+            "completeness, clarity, and contribution to knowledge. Editors (initially Joshua "
+            "Tan as lead, with Michael Zargham) coordinate review processes, make publication "
+            "decisions, and maintain infrastructure. Readers access documented patterns for "
+            "learning and adaptation. Metagov provides organizational home and alignment with "
+            "digital self-governance mission, with research directors Seth Frey and Ellie "
+            "Rennie providing oversight."
+        ),
+        3: (
+            "The journal operates within overlapping contexts. Technically, it depends on "
+            "GitHub for version control and collaboration, technical platforms for archival "
+            "storage and DOIs. Academically, it bridges scholarly publishing conventions with "
+            "open-source software practices. Legally, it operates under Metagov's nonprofit "
+            "structure. Normatively, it inherits from both peer review traditions and GitHub "
+            "collaboration patterns. Economically, it functions as a scholarly club good "
+            "where contribution enables access to curated knowledge."
+        ),
+        4: (
+            "The foundational rules emerge from three layers. The Catechism (nine questions) "
+            "structures all submissions, creating comparable documentation. The Review "
+            "Criteria define evaluation standards — completeness, clarity, evidence, "
+            "viability, and contribution. The GitHub Flow establishes procedural rules — "
+            "fork, submit PR, review, revise, merge."
+        ),
+        5: (
+            "Primary activity occurs at github.com/metagov/journal — submissions, reviews, "
+            "and discussions. The Metagov website offers organizational context. Joshua "
+            "Tan's introductory blog post articulates the founding vision."
+        ),
+        6: (
+            "As author of this draft, I am a systems engineer and protocol architect with "
+            "deep experience in open source communities — my role in Metagov is often to "
+            "map systems and provide operational policy recommendations. Joshua Tan, "
+            "Metagov co-founder and journal's primary driver, provides vision and "
+            "organizational support. We both serve on Metagov's board, creating alignment "
+            "but also potential conflicts of interest."
+        ),
+        7: (
+            "The journal emerged from Joshua Tan's observation that governance experiments "
+            "in DAOs, cooperatives, and digital communities generate valuable innovations "
+            "but lack documentation venues. In late 2024, Tan convened Metagov research "
+            "directors to design a solution. The founding team brought complementary "
+            "perspectives: Tan (platform governance), Zargham (systems engineering), Frey "
+            "(cognitive science), Rennie (digital ethnography)."
+        ),
+        8: (
+            "Evolution operates through multiple mechanisms. Immediate adaptation happens "
+            "via GitHub. Periodic review occurs quarterly as editors assess processes and "
+            "incorporate lessons. Version control enables framework evolution while "
+            "maintaining citation stability through semantic versioning. Community feedback "
+            "shapes development through discussions and reviews. Scaling triggers activate "
+            "new processes as volume grows."
+        ),
+        9: (
+            "Foundational documents and academic references that ground the journal's "
+            "design and motivate its operating model."
+        ),
+    }
+    for q, text in narratives.items():
+        run(["narrative", SLUG, "--question", str(q), text])
+
+    step("Q2 — stakeholders")
+    for role_label, role_slug, person, resp in [
+        ("Editor", "editor", "joshua-tan", "Lead editor; coordinates review and publication."),
+        ("Editor", "editor", "michael-zargham", "Co-editor; infrastructure and operations."),
+        ("Research Director", "research-director", "seth-frey", "Provides oversight; cognitive-science perspective."),
+        ("Research Director", "research-director", "ellie-rennie", "Provides oversight; digital-ethnography perspective."),
+    ]:
+        run(
+            [
+                "stakeholder",
+                "add",
+                SLUG,
+                "--role-label",
+                role_label,
+                "--role-slug",
+                role_slug,
+                "--person",
+                person,
+                "--responsibilities",
+                resp,
+            ]
+        )
+    # Org-level stakeholder
+    run(
+        [
+            "stakeholder",
+            "add",
+            SLUG,
+            "--role-label",
+            "Organizational Home",
+            "--role-slug",
+            "organizational-home",
+            "--org",
+            "metagov",
+            "--responsibilities",
+            "Provides nonprofit infrastructure and mission alignment.",
+        ]
+    )
+
+    step("Q3 — environmental factors (Lessig modalities)")
+    factors = [
+        ("Architecture", "GitHub provides version control, peer-review tooling, and collaboration infrastructure."),
+        ("Norms", "Inherits scholarly peer-review traditions and open-source GitHub collaboration patterns."),
+        ("Markets", "Functions as a scholarly club good: contribution enables access to curated knowledge."),
+        ("Law", "Operates under Metagov's nonprofit structure; subject to nonprofit governance regulation."),
+    ]
+    for modality, desc in factors:
+        run(["factor", "add", SLUG, "--modality", modality, "--description", desc])
+
+    step("Q4 — constitutional elements")
+    elements = [
+        ("Catechism", "Bylaw", "Nine-question framework that structures every submission, creating comparable documentation."),
+        ("Review Criteria", "Bylaw", "Evaluation standards — completeness, clarity, evidence, viability, contribution."),
+        ("GitHub Flow", "DecisionProcedure", "Procedural rules — fork, submit PR, review, revise, merge."),
+        ("Editorial Norms", "Norm", "Constructive feedback tone, reasonable review timelines, transparency in decision-making."),
+    ]
+    for label, etype, desc in elements:
+        run(["constitution", "add", SLUG, "--label", label, "--type", etype, "--description", desc])
+
+    step("Q5 — field sites")
+    for label, url, desc in [
+        ("GitHub repository", "https://github.com/metagov/metagov-journal", "Primary site for submissions, reviews, and discussion."),
+        ("Metagov website", "https://metagov.org", "Organizational home and mission context."),
+        ("Founding blog post", "https://journal.metagov.org/2025/08/09/metagov-journal.html", "Joshua Tan's introductory articulation of the journal's vision."),
+    ]:
+        run(["fieldsite", "add", SLUG, "--label", label, "--url", url, "--description", desc])
+
+    step("Q6 — author disclosure")
+    run(
+        [
+            "author",
+            "set",
+            SLUG,
+            "--person",
+            "michael-zargham",
+            "--role",
+            "co-editor and board member",
+            "--disclosure",
+            "Author serves on Metagov's board with Joshua Tan; potential conflict of interest. Bootstrap submission receives review from fellow research directors rather than external reviewers. Blind spots likely include overemphasis on technical mechanisms.",
+        ]
+    )
+
+    step("Q7 — origin event")
+    run(
+        [
+            "origin",
+            "add",
+            SLUG,
+            "--label",
+            "Founding convening",
+            "--description",
+            "In late 2024, Joshua Tan convened Metagov research directors to design a journal for documenting living institutions.",
+            "--date",
+            "2024-11-01",
+            "--persons",
+            "joshua-tan,michael-zargham,seth-frey,ellie-rennie",
+        ]
+    )
+
+    step("Q8 — evolution mechanisms")
+    for label, desc in [
+        ("PR-driven amendment", "Anyone can propose changes to framework documents through GitHub issues and pull requests."),
+        ("Quarterly editorial review", "Editors assess processes and incorporate lessons each quarter."),
+        ("Semantic versioning", "Framework evolution preserves citation stability via versioned releases."),
+    ]:
+        run(["evolution", "add", SLUG, "--label", label, "--description", desc])
+
+    step("Q9 — references")
+    refs = [
+        ("Introducing the Metagov Journal", "https://journal.metagov.org/2025/08/09/metagov-journal.html", "Joshua Tan", "2025"),
+        ("Protocols and Institutions", "https://zenodo.org/records/15122312", "Michael Zargham,Ilan Ben-Meir", "2024"),
+        ("What Constitutes a Constitution", "https://zenodo.org/records/10609125", "Michael Zargham", "2023"),
+        ("A Journal is a Club", "https://www.tandfonline.com/doi/abs/10.1080/08109028.2017.1386949", "Jason Potts", "2017"),
+    ]
+    for title, ident, creators, date in refs:
+        run(["reference", "add", SLUG, "--title", title, "--identifier", ident, "--creators", creators, "--date", date])
+
+    step("Legal context")
+    run(
+        [
+            "legal",
+            "set",
+            SLUG,
+            "--host",
+            "metagov",
+            "--relationship",
+            "FiscalSponsor",
+            "--description",
+            "The journal operates under Metagov's 501(c)(3) nonprofit infrastructure.",
+        ]
+    )
+
+    step("validate (system SHACL)")
+    run(["validate", SLUG])
+
+    step("compile")
+    run(["compile", SLUG])
+
+    step("regenerate wiki")
+    run(["wiki"])
+
+    print("\n✓ self-submission built end-to-end.")
+
+
+if __name__ == "__main__":
+    main()

--- a/shared/organizations.ttl
+++ b/shared/organizations.ttl
@@ -1,0 +1,8 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<https://journal.metagov.org/orgs/metagov>
+    a foaf:Organization ;
+    foaf:homepage "https://metagov.org"^^xsd:anyURI ;
+    foaf:name "Metagov" ;
+.

--- a/shared/people.ttl
+++ b/shared/people.ttl
@@ -1,0 +1,21 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+<https://journal.metagov.org/people/ellie-rennie>
+    a foaf:Person ;
+    foaf:name "Ellie Rennie" ;
+.
+
+<https://journal.metagov.org/people/joshua-tan>
+    a foaf:Person ;
+    foaf:name "Joshua Tan" ;
+.
+
+<https://journal.metagov.org/people/michael-zargham>
+    a foaf:Person ;
+    foaf:name "Michael Zargham" ;
+.
+
+<https://journal.metagov.org/people/seth-frey>
+    a foaf:Person ;
+    foaf:name "Seth Frey" ;
+.

--- a/shared/vocabularies.ttl
+++ b/shared/vocabularies.ttl
@@ -1,0 +1,15 @@
+# =============================================================================
+# Shared Vocabularies Registry
+#
+# Open SKOS schemes that grow over time (mgj:RoleType). Closed schemes
+# (mgj:LessigModalities, mgj:ConstitutionalElementType) live in the
+# ontology. New role concepts are added here via `mgj` CLI when
+# stakeholders introduce previously-unseen role labels.
+# =============================================================================
+
+@prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+@prefix mgjr:    <https://journal.metagov.org/roles/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+# (role concepts added by CLI as new submissions introduce them)

--- a/src/mgj/__init__.py
+++ b/src/mgj/__init__.py
@@ -1,0 +1,5 @@
+from rdflib import Namespace
+
+__version__ = "0.1.0"
+
+MGJ = Namespace("https://journal.metagov.org/ns/mgj#")

--- a/src/mgj/canonicalize.py
+++ b/src/mgj/canonicalize.py
@@ -1,0 +1,136 @@
+"""
+mgj.canonicalize
+----------------
+Deterministic RDF canonicalization for content-addressable graphs.
+
+Two outputs:
+
+- ``canonical_nt(g)`` — sorted N-Triples string. Hash-stable: any two
+  isomorphic graphs produce byte-identical output. Use for content
+  hashing and equality comparisons.
+
+- ``canonicalize_turtle(g)`` — stable Turtle string for human-readable
+  storage. Uses rdflib's ``longturtle`` serializer over a URDNA2015-
+  canonicalized graph, with mgj's canonical prefixes pre-bound. Within
+  a given rdflib version this is byte-stable.
+
+The two outputs serve different purposes: the N-Triples hash is the
+authoritative content identity (rdflib-version independent); the Turtle
+form is what we store on disk.
+
+Round-trip invariant:
+    parse(canonicalize_turtle(g)) hashes to graph_hash(g)
+
+Idempotence invariant:
+    canonicalize_turtle(parse(canonicalize_turtle(g))) == canonicalize_turtle(g)
+
+Both are exercised by tests/test_canonicalize.py.
+"""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+
+from rdflib import Graph
+from rdflib.compare import to_canonical_graph
+from rdflib.namespace import DCTERMS, FOAF, RDF, RDFS, SKOS, XSD
+
+from mgj.namespaces import MGJ, PROV
+
+
+def _canonical_graph_with_prefixes(g: Graph) -> Graph:
+    """URDNA2015-canonicalize and re-bind the mgj canonical prefixes.
+
+    ``to_canonical_graph`` returns a read-only aggregate, so we copy its
+    triples into a fresh, mutable Graph and bind our standard prefixes
+    on the copy. This yields readable Turtle that uses our prefixes
+    instead of auto-generated ``ns1``/``ns2`` placeholders.
+    """
+    canonical = to_canonical_graph(g)
+    cg = Graph()
+    for t in canonical:
+        cg.add(t)
+    cg.bind("mgj", MGJ, override=True)
+    cg.bind("foaf", FOAF, override=True)
+    cg.bind("dcterms", DCTERMS, override=True)
+    cg.bind("skos", SKOS, override=True)
+    cg.bind("prov", PROV, override=True)
+    cg.bind("rdfs", RDFS, override=True)
+    cg.bind("rdf", RDF, override=True)
+    cg.bind("xsd", XSD, override=True)
+    return cg
+
+
+def canonical_nt(g: Graph) -> str:
+    """Sorted N-Triples form of ``g``. Byte-stable for isomorphic graphs.
+
+    Used for content hashing. The output is sorted line-by-line on the
+    URDNA2015-canonicalized graph, so reordering the source has no effect
+    and blank nodes get deterministic labels.
+    """
+    cg = to_canonical_graph(g)
+    raw = cg.serialize(format="nt")
+    lines = [line for line in raw.splitlines() if line.strip()]
+    return "\n".join(sorted(lines)) + "\n"
+
+
+def graph_hash(g: Graph, *, algorithm: str = "sha256") -> str:
+    """Hex digest of the canonical N-Triples form. Default: SHA-256.
+
+    Two isomorphic graphs produce identical hashes regardless of triple
+    insertion order, blank node labeling, or prefix choices in the
+    Turtle source.
+    """
+    if algorithm != "sha256":
+        raise ValueError(f"unsupported algorithm: {algorithm!r}")
+    return sha256(canonical_nt(g).encode("utf-8")).hexdigest()
+
+
+def canonicalize_turtle(g: Graph) -> str:
+    """Stable Turtle serialization with canonical mgj prefixes.
+
+    Within a given rdflib version, this is byte-stable: the same graph
+    always produces the same string. Across rdflib versions we make no
+    guarantee — use ``graph_hash`` for cross-version content addressing.
+    """
+    cg = _canonical_graph_with_prefixes(g)
+    return cg.serialize(format="longturtle")
+
+
+def canonicalize_file(path: str | Path) -> bool:
+    """Parse ``path``, canonicalize, write back. Returns True if changed.
+
+    Idempotent: calling twice in succession on the same file produces no
+    change on the second call. Use this after every CLI mutation so the
+    on-disk Turtle stays in canonical form regardless of how triples
+    were added.
+    """
+    p = Path(path)
+    g = Graph()
+    g.parse(str(p), format="turtle")
+    canonical = canonicalize_turtle(g)
+    if not p.exists() or p.read_text() != canonical:
+        p.write_text(canonical)
+        return True
+    return False
+
+
+def save_instance(g: Graph, path: str | Path) -> None:
+    """Write ``g`` to ``path`` in canonical Turtle form.
+
+    Use from CLI command handlers in place of ``g.serialize(...)`` to
+    guarantee on-disk canonicality.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(canonicalize_turtle(g))
+
+
+__all__ = [
+    "canonical_nt",
+    "graph_hash",
+    "canonicalize_turtle",
+    "canonicalize_file",
+    "save_instance",
+]

--- a/src/mgj/cli.py
+++ b/src/mgj/cli.py
@@ -1,0 +1,73 @@
+"""
+mgj.cli
+-------
+Top-level Typer entry point.
+
+Wires the lifecycle, registry, entity, and affirmation command modules
+into a single ``mgj`` CLI.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from mgj.commands.affirm import app as affirm_app
+from mgj.commands.compile import compile_app, wiki_app
+from mgj.commands.extract import app as extract_app
+from mgj.commands.entities import (
+    author_app,
+    constitution_app,
+    evolution_app,
+    factor_app,
+    fieldsite_app,
+    legal_app,
+    origin_app,
+    reference_app,
+    stakeholder_app,
+)
+from mgj.commands.lifecycle import app as lifecycle_app
+from mgj.commands.registries import orgs_app, people_app
+
+app = typer.Typer(
+    no_args_is_help=True,
+    help="Metagov Journal — RDF-native catechism authoring CLI.",
+)
+
+# Lifecycle commands (init, status, validate, canonicalize, narrative)
+# are top-level rather than nested under a sub-typer, so users can write
+# `mgj init …` instead of `mgj lifecycle init …`. Typer's `add_typer`
+# does not flatten cleanly, so we register each as a top-level command.
+for command_info in lifecycle_app.registered_commands:
+    app.registered_commands.append(command_info)
+
+# Affirmation commands likewise top-level (affirm, unaffirm, review).
+for command_info in affirm_app.registered_commands:
+    app.registered_commands.append(command_info)
+
+# Entity sub-typers
+app.add_typer(stakeholder_app, name="stakeholder")
+app.add_typer(factor_app, name="factor")
+app.add_typer(constitution_app, name="constitution")
+app.add_typer(fieldsite_app, name="fieldsite")
+app.add_typer(origin_app, name="origin")
+app.add_typer(evolution_app, name="evolution")
+app.add_typer(reference_app, name="reference")
+app.add_typer(legal_app, name="legal")
+app.add_typer(author_app, name="author")
+
+# Compilers + parser — register as top-level commands by lifting their
+# Typer.registered_commands onto the main app.
+for command_info in compile_app.registered_commands:
+    app.registered_commands.append(command_info)
+for command_info in wiki_app.registered_commands:
+    app.registered_commands.append(command_info)
+for command_info in extract_app.registered_commands:
+    app.registered_commands.append(command_info)
+
+# Shared registry sub-typers
+app.add_typer(people_app, name="people")
+app.add_typer(orgs_app, name="orgs")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/mgj/commands/_common.py
+++ b/src/mgj/commands/_common.py
@@ -1,0 +1,292 @@
+"""
+mgj.commands._common
+--------------------
+Shared helpers for CLI command modules.
+
+Every CLI mutation flows through ``with_mutation`` so the database
+invariant holds:
+    1. Load instance.ttl + shared registries into a graph.
+    2. Apply mutation in-memory.
+    3. Run per-question SHACL on the affected Qi (if any).
+    4. If validation fails, abort with a structured error and leave
+       the on-disk file unchanged.
+    5. Otherwise canonicalize and save.
+
+Affirmation state lives in ``submissions/<slug>/extraction-trace.json``
+rather than on RDF triples — see ``load_trace`` / ``save_trace``.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterator
+
+import typer
+from rdflib import Graph, Literal, URIRef
+from rich.console import Console
+from rich.table import Table
+
+from mgj.canonicalize import canonicalize_turtle
+from mgj.graph import (
+    SHARED_DIR,
+    SUBMISSIONS_DIR,
+    sparql_select,
+    submission_dir,
+    submission_instance_path,
+)
+from mgj.namespaces import MGJ, submission_entity_iri, submission_iri
+from mgj.validate import ValidationReport, validate
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+# ---------------------------------------------------------------------------
+# Affirmation / extraction trace
+# ---------------------------------------------------------------------------
+
+TRACE_FILENAME = "extraction-trace.json"
+
+
+@dataclass
+class ExtractionTrace:
+    slug: str
+    version: str
+    affirmed_questions: dict[int, str | None] = field(default_factory=dict)
+    """question number -> ISO timestamp of affirmation (or None)."""
+    extractions: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "slug": self.slug,
+            "version": self.version,
+            "affirmed_questions": {str(k): v for k, v in self.affirmed_questions.items()},
+            "extractions": self.extractions,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ExtractionTrace":
+        return cls(
+            slug=data["slug"],
+            version=data["version"],
+            affirmed_questions={int(k): v for k, v in data.get("affirmed_questions", {}).items()},
+            extractions=data.get("extractions", []),
+        )
+
+
+def trace_path(slug: str) -> Path:
+    return submission_dir(slug) / TRACE_FILENAME
+
+
+def load_trace(slug: str) -> ExtractionTrace:
+    p = trace_path(slug)
+    if not p.exists():
+        raise typer.BadParameter(
+            f"submission '{slug}' has no extraction-trace.json — run `mgj init {slug}` first"
+        )
+    return ExtractionTrace.from_dict(json.loads(p.read_text()))
+
+
+def save_trace(trace: ExtractionTrace) -> None:
+    p = trace_path(trace.slug)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(trace.to_dict(), indent=2, sort_keys=True) + "\n")
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Graph load / save with shared registries
+# ---------------------------------------------------------------------------
+
+
+def _merge_shared(g: Graph) -> None:
+    if SHARED_DIR.is_dir():
+        for ttl in sorted(SHARED_DIR.glob("*.ttl")):
+            g.parse(str(ttl), format="turtle")
+
+
+def load_submission_graph(slug: str, *, merge_shared: bool = True) -> Graph:
+    """Load instance.ttl, optionally merging shared registries.
+
+    The shared registries are merged so SHACL validation sees foaf:Person
+    and foaf:Organization triples for resolution checks.
+    """
+    p = submission_instance_path(slug)
+    if not p.exists():
+        raise typer.BadParameter(
+            f"submission '{slug}' has no instance.ttl at {p} — run `mgj init {slug}` first"
+        )
+    g = Graph()
+    if merge_shared:
+        _merge_shared(g)
+    g.parse(str(p), format="turtle")
+    return g
+
+
+def save_submission_graph_separating_shared(g: Graph, slug: str) -> None:
+    """Write only the per-submission triples to instance.ttl in canonical form.
+
+    Triples whose subjects live in the shared registries (people/orgs) are
+    excluded from the per-submission graph so we don't duplicate them on disk.
+    """
+    submission_only = Graph()
+    shared_subjects = _shared_subject_iris()
+    for s, p, o in g:
+        if str(s) in shared_subjects:
+            continue
+        submission_only.add((s, p, o))
+
+    out = submission_instance_path(slug)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(canonicalize_turtle(submission_only))
+
+
+def _shared_subject_iris() -> set[str]:
+    """All subject IRIs that live in shared/*.ttl. Used to keep them out of
+    instance.ttl when we save."""
+    g = Graph()
+    _merge_shared(g)
+    return {str(s) for s in g.subjects()}
+
+
+# ---------------------------------------------------------------------------
+# Submission identity helpers
+# ---------------------------------------------------------------------------
+
+
+def get_submission_iri(g: Graph, slug: str) -> URIRef:
+    """Find the single mgj:Submission IRI in this graph and confirm it
+    matches ``slug``. Errors loudly if zero or multiple are found."""
+    rows = sparql_select(g, "SELECT ?s WHERE { ?s a mgj:Submission }")
+    if not rows:
+        raise typer.BadParameter(f"no mgj:Submission found in instance for '{slug}'")
+    if len(rows) > 1:
+        raise typer.BadParameter(
+            f"expected one mgj:Submission per instance.ttl; found {len(rows)} for '{slug}'"
+        )
+    return URIRef(rows[0]["s"])
+
+
+def get_submission_version(g: Graph, slug: str) -> str:
+    sub = get_submission_iri(g, slug)
+    rows = sparql_select(
+        g,
+        f"SELECT ?v WHERE {{ <{sub}> mgj:submissionVersion ?v }}",
+    )
+    if not rows:
+        raise typer.BadParameter(
+            f"submission for '{slug}' has no mgj:submissionVersion triple"
+        )
+    return rows[0]["v"]
+
+
+def next_local_id(g: Graph, slug: str, version: str, kind: str, owl_class: str) -> str:
+    """Find the next available numeric local id for entities of `kind`.
+
+    ``owl_class`` is the OWL class local name (e.g. 'Stakeholder') used to
+    locate existing entities of this kind.
+    """
+    base = submission_entity_iri(slug, version, kind, "")
+    rows = sparql_select(
+        g,
+        f"SELECT ?s WHERE {{ ?s a mgj:{owl_class} }}",
+    )
+    nums: list[int] = []
+    for row in rows:
+        iri = row["s"]
+        if iri.startswith(base):
+            tail = iri[len(base):]
+            if tail.isdigit():
+                nums.append(int(tail))
+    return str(max(nums, default=0) + 1)
+
+
+# ---------------------------------------------------------------------------
+# Mutation framework
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def with_mutation(slug: str, *, question: int | None = None) -> Iterator[Graph]:
+    """Context manager that loads, yields the graph for in-memory mutation,
+    then validates (per-Q if ``question`` is set, otherwise no validation),
+    and saves.
+
+    On validation failure, raises ``typer.Exit(1)`` after printing a
+    structured violation report. The on-disk file is *not* updated."""
+    g = load_submission_graph(slug, merge_shared=True)
+    yield g
+
+    if question is not None:
+        report = validate(g, mode="per_question", question=question)
+        if not report.conforms:
+            err_console.print(f"[red]rejected: Q{question} validation failed[/red]")
+            for v in report.violations:
+                err_console.print(f"  • {v.message}  (focus={v.focus_node})")
+            raise typer.Exit(code=1)
+
+    save_submission_graph_separating_shared(g, slug)
+
+
+def report_validation(report: ValidationReport, *, label: str = "") -> None:
+    if report.conforms:
+        console.print(f"[green]✓ {label or 'OK'}[/green]")
+        return
+    console.print(f"[red]✗ {label or 'FAIL'}[/red]: {report.violation_count} violation(s)")
+    for v in report.violations:
+        console.print(f"  • {v.message}")
+        if v.result_path:
+            console.print(f"    path: {v.result_path}")
+        console.print(f"    focus: {v.focus_node}")
+
+
+# ---------------------------------------------------------------------------
+# Shared registry IO
+# ---------------------------------------------------------------------------
+
+
+def shared_path(filename: str) -> Path:
+    return SHARED_DIR / filename
+
+
+def load_shared_registry(filename: str) -> Graph:
+    p = shared_path(filename)
+    g = Graph()
+    if p.exists():
+        g.parse(str(p), format="turtle")
+    return g
+
+
+def save_shared_registry(g: Graph, filename: str) -> None:
+    p = shared_path(filename)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(canonicalize_turtle(g))
+
+
+__all__ = [
+    "ExtractionTrace",
+    "TRACE_FILENAME",
+    "console",
+    "err_console",
+    "trace_path",
+    "load_trace",
+    "save_trace",
+    "now_iso",
+    "load_submission_graph",
+    "save_submission_graph_separating_shared",
+    "get_submission_iri",
+    "get_submission_version",
+    "next_local_id",
+    "with_mutation",
+    "report_validation",
+    "shared_path",
+    "load_shared_registry",
+    "save_shared_registry",
+]

--- a/src/mgj/commands/affirm.py
+++ b/src/mgj/commands/affirm.py
@@ -1,0 +1,162 @@
+"""
+mgj.commands.affirm
+-------------------
+Per-question affirmation tracking and a textual review dump.
+
+Affirmation state lives in ``submissions/<slug>/extraction-trace.json``
+rather than on RDF triples. Affirming Qi means: the parser's output for
+that question has been reviewed and confirmed by the author. Affirmation
+is sticky against re-extraction (M5 enforces this in reconcile.py).
+"""
+
+from __future__ import annotations
+
+import typer
+from rdflib import URIRef
+from rich.panel import Panel
+
+from mgj.commands._common import (
+    console,
+    err_console,
+    get_submission_iri,
+    load_submission_graph,
+    load_trace,
+    now_iso,
+    save_trace,
+)
+from mgj.namespaces import MGJ
+from mgj.validate import validate
+
+app = typer.Typer(no_args_is_help=True, help="Per-question affirmation.")
+
+
+@app.command()
+def affirm(
+    slug: str = typer.Argument(...),
+    question: int = typer.Option(..., "--question", "-q", help="1..9"),
+) -> None:
+    """Mark Qi as affirmed. Runs per-Q SHACL first; rejects if it fails."""
+    if not 1 <= question <= 9:
+        raise typer.BadParameter("question must be 1..9")
+    g = load_submission_graph(slug)
+    report = validate(g, mode="per_question", question=question)
+    if not report.conforms:
+        err_console.print(
+            f"[red]rejected: Q{question} failed per-question validation[/red]"
+        )
+        for v in report.violations:
+            err_console.print(f"  • {v.message}")
+        raise typer.Exit(code=1)
+
+    trace = load_trace(slug)
+    trace.affirmed_questions[question] = now_iso()
+    save_trace(trace)
+    console.print(f"[green]✓ Q{question} affirmed[/green]")
+
+
+@app.command()
+def unaffirm(
+    slug: str = typer.Argument(...),
+    question: int = typer.Option(..., "--question", "-q"),
+) -> None:
+    """Clear affirmation for Qi. Use before re-extracting."""
+    trace = load_trace(slug)
+    trace.affirmed_questions[question] = None
+    save_trace(trace)
+    console.print(f"[yellow]– Q{question} affirmation cleared[/yellow]")
+
+
+@app.command()
+def review(
+    slug: str = typer.Argument(...),
+    question: int = typer.Option(..., "--question", "-q"),
+) -> None:
+    """Render the current state of Qi: narrative + typed entities + violations."""
+    g = load_submission_graph(slug)
+    sub = get_submission_iri(g, slug)
+    nar_prop = MGJ[f"q{question}Narrative"]
+    nar = next(g.objects(sub, nar_prop), None)
+
+    panel_body = []
+    if nar is not None:
+        panel_body.append(f"[bold]narrative[/bold]\n{str(nar)}")
+    else:
+        panel_body.append("[dim]narrative not set[/dim]")
+
+    panel_body.append("")
+    panel_body.append("[bold]entities[/bold]")
+    panel_body.append(_render_entities(g, question))
+
+    console.print(Panel("\n".join(panel_body), title=f"Q{question} review — {slug}"))
+
+    report = validate(g, mode="per_question", question=question)
+    if report.conforms:
+        console.print(f"[green]✓ Q{question} per-question SHACL passes[/green]")
+    else:
+        console.print(
+            f"[red]✗ Q{question} per-question SHACL fails: "
+            f"{report.violation_count} violation(s)[/red]"
+        )
+        for v in report.violations:
+            console.print(f"  • {v.message}")
+
+    trace = load_trace(slug)
+    affirmed = trace.affirmed_questions.get(question)
+    console.print(f"affirmed: [bold]{affirmed or '—'}[/bold]")
+
+
+def _render_entities(g, question: int) -> str:
+    """Render the entities for a given question as plain text."""
+    from rdflib import RDF, Literal
+
+    rows: list[str] = []
+    if question == 2:
+        for s in sorted(g.subjects(RDF.type, MGJ.Stakeholder)):
+            agent = next(g.objects(s, MGJ.stakeholderAgent), URIRef(""))
+            role = next(g.objects(s, MGJ.roleLabel), Literal(""))
+            rows.append(
+                f"  · stakeholder {_id(s)}: agent={_short(agent)} role={role}"
+            )
+    elif question == 3:
+        for s in sorted(g.subjects(RDF.type, MGJ.EnvironmentalFactor)):
+            mod = next(g.objects(s, MGJ.lessigModality), URIRef(""))
+            desc = next(g.objects(s, MGJ.factorDescription), Literal(""))
+            rows.append(f"  · factor {_id(s)} [{_short(mod)}]: {desc}")
+    elif question == 4:
+        for s in sorted(g.subjects(RDF.type, MGJ.ConstitutionalElement)):
+            label = next(g.objects(s, MGJ.elementLabel), Literal(""))
+            etype = next(g.objects(s, MGJ.elementType), URIRef(""))
+            rows.append(f"  · constitution {_id(s)} [{_short(etype)}]: {label}")
+    elif question == 5:
+        for s in sorted(g.subjects(RDF.type, MGJ.FieldSite)):
+            label = next(g.objects(s, MGJ.fieldSiteLabel), Literal(""))
+            url = next(g.objects(s, MGJ.fieldSiteURL), Literal(""))
+            rows.append(f"  · fieldsite {_id(s)}: {label} {url}".rstrip())
+    elif question == 7:
+        for s in sorted(g.subjects(RDF.type, MGJ.OriginEvent)):
+            label = next(g.objects(s, MGJ.originLabel), Literal(""))
+            d = next(g.objects(s, MGJ.originDate), Literal(""))
+            rows.append(f"  · origin {_id(s)}: {label} ({d})")
+    elif question == 8:
+        for s in sorted(g.subjects(RDF.type, MGJ.EvolutionMechanism)):
+            label = next(g.objects(s, MGJ.mechanismLabel), Literal(""))
+            rows.append(f"  · evolution {_id(s)}: {label}")
+    elif question == 9:
+        from rdflib.namespace import DCTERMS
+
+        for s in sorted(g.subjects(RDF.type, MGJ.Reference)):
+            title = next(g.objects(s, DCTERMS.title), Literal(""))
+            ident = next(g.objects(s, DCTERMS.identifier), Literal(""))
+            rows.append(f"  · reference {_id(s)}: {title} ({ident})")
+    return "\n".join(rows) if rows else "  [dim](none)[/dim]"
+
+
+def _id(s) -> str:
+    return str(s).rsplit("/", 1)[-1]
+
+
+def _short(uri) -> str:
+    s = str(uri)
+    if "#" in s:
+        return s.rsplit("#", 1)[-1]
+    return s.rsplit("/", 1)[-1]

--- a/src/mgj/commands/compile.py
+++ b/src/mgj/commands/compile.py
@@ -1,0 +1,48 @@
+"""
+mgj.commands.compile
+--------------------
+``mgj compile <slug>`` and ``mgj wiki [--output DIR]``.
+
+Both are top-level commands implemented in their own minimal Typer apps;
+``cli.py`` merges them into the main app via ``registered_commands``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from mgj.commands._common import console, err_console
+from mgj.compilers.catechism import compile_submission_file
+from mgj.compilers.wiki import compile_wiki
+from mgj.graph import project_root, submission_dir, submission_instance_path
+
+compile_app = typer.Typer()
+wiki_app = typer.Typer()
+
+
+@compile_app.command(name="compile")
+def compile_cmd(
+    slug: str = typer.Argument(..., help="Submission slug to compile"),
+) -> None:
+    """Render <slug>/instance.ttl into <slug>/compiled.md."""
+    instance = submission_instance_path(slug)
+    if not instance.exists():
+        err_console.print(f"[red]no instance.ttl at {instance}[/red]")
+        raise typer.Exit(code=1)
+    output = submission_dir(slug) / "compiled.md"
+    output.write_text(compile_submission_file(instance))
+    console.print(f"[green]✓ compiled[/green] {output}")
+
+
+@wiki_app.command(name="wiki")
+def wiki_cmd(
+    output_dir: str = typer.Option(
+        None, "--output", "-o", help="Output directory (default: <repo>/wiki)"
+    ),
+) -> None:
+    """Generate the cross-linked wiki under wiki/ (or --output DIR)."""
+    out = Path(output_dir) if output_dir else project_root() / "wiki"
+    written = compile_wiki(out)
+    console.print(f"[green]✓ wrote {len(written)} wiki page(s)[/green] to {out}")

--- a/src/mgj/commands/entities.py
+++ b/src/mgj/commands/entities.py
@@ -1,0 +1,655 @@
+"""
+mgj.commands.entities
+---------------------
+Per-entity CLI command groups for catechism Q2..Q9 and the cross-Q
+LegalContext. Every mutation goes through ``with_mutation`` so the
+canonicalize+validate+save invariant holds.
+
+One sub-typer per entity type:
+    stakeholder  Q2
+    factor       Q3 (environmental factor)
+    constitution Q4 (constitutional element)
+    fieldsite    Q5
+    origin       Q7 (origin event)
+    evolution    Q8 (evolution mechanism)
+    reference    Q9
+    legal        cross-Q (legal context)
+"""
+
+from __future__ import annotations
+
+from datetime import date as DateT
+
+import typer
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import DCTERMS, FOAF, RDF, SKOS, XSD
+from rich.table import Table
+
+from mgj.commands._common import (
+    console,
+    err_console,
+    get_submission_iri,
+    get_submission_version,
+    load_submission_graph,
+    next_local_id,
+    with_mutation,
+)
+from mgj.namespaces import (
+    MGJ,
+    organization_iri,
+    person_iri,
+    role_iri,
+    submission_entity_iri,
+)
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_agent(g: Graph, person: str | None, org: str | None) -> URIRef:
+    if (person is None) == (org is None):
+        raise typer.BadParameter("provide exactly one of --person or --org")
+    if person:
+        iri = URIRef(person_iri(person))
+        if (iri, RDF.type, FOAF.Person) not in g:
+            raise typer.BadParameter(
+                f"person '{person}' not in shared/people.ttl — run `mgj people add` first"
+            )
+        return iri
+    iri = URIRef(organization_iri(org))
+    if (iri, RDF.type, FOAF.Organization) not in g:
+        raise typer.BadParameter(
+            f"org '{org}' not in shared/organizations.ttl — run `mgj orgs add` first"
+        )
+    return iri
+
+
+def _ensure_role_concept(g: Graph, role_slug: str, role_label: str) -> URIRef:
+    iri = URIRef(role_iri(role_slug))
+    if (iri, RDF.type, SKOS.Concept) not in g:
+        g.add((iri, RDF.type, SKOS.Concept))
+        g.add((iri, SKOS.inScheme, MGJ.RoleType))
+        g.add((iri, SKOS.prefLabel, Literal(role_label)))
+    return iri
+
+
+def _entity_iri(slug: str, version: str, kind: str, local_id: str) -> URIRef:
+    return URIRef(submission_entity_iri(slug, version, kind, local_id))
+
+
+def _local_id_from_iri(iri: str) -> str:
+    return iri.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _remove_subject(g: Graph, subj: URIRef) -> None:
+    """Remove all triples where ``subj`` is subject. Object-position triples
+    are left in place (the link from Submission to subj is removed by the
+    caller via the link predicate)."""
+    for p, o in list(g.predicate_objects(subj)):
+        g.remove((subj, p, o))
+
+
+# ---------------------------------------------------------------------------
+# Q2 — stakeholder
+# ---------------------------------------------------------------------------
+
+stakeholder_app = typer.Typer(no_args_is_help=True, help="Q2 — stakeholders.")
+
+
+@stakeholder_app.command("add")
+def stakeholder_add(
+    slug: str = typer.Argument(...),
+    role_label: str = typer.Option(..., "--role-label", help="e.g. 'Editor', 'Reviewer'"),
+    role_slug: str = typer.Option(
+        ..., "--role-slug", help="URL-safe role slug, e.g. 'editor'"
+    ),
+    person: str = typer.Option(None, "--person", help="Slug from shared/people.ttl"),
+    org: str = typer.Option(None, "--org", help="Slug from shared/organizations.ttl"),
+    responsibilities: str = typer.Option(None, "--responsibilities"),
+) -> None:
+    with with_mutation(slug, question=2) as g:
+        sub = get_submission_iri(g, slug)
+        version = get_submission_version(g, slug)
+        agent = _resolve_agent(g, person, org)
+        role = _ensure_role_concept(g, role_slug, role_label)
+        lid = next_local_id(g, slug, version, "stakeholder", "Stakeholder")
+        node = _entity_iri(slug, version, "stakeholder", lid)
+        g.add((node, RDF.type, MGJ.Stakeholder))
+        g.add((node, MGJ.stakeholderAgent, agent))
+        g.add((node, MGJ.roleLabel, Literal(role_label)))
+        g.add((node, MGJ.hasRole, role))
+        if responsibilities:
+            g.add((node, MGJ.stakeholderResponsibilities, Literal(responsibilities)))
+        g.add((sub, MGJ.hasStakeholder, node))
+    console.print(f"[green]✓ added stakeholder {lid}[/green]")
+
+
+@stakeholder_app.command("list")
+def stakeholder_list(slug: str = typer.Argument(...)) -> None:
+    g = load_submission_graph(slug)
+    table = Table("id", "agent", "role", "responsibilities")
+    for s in sorted(g.subjects(RDF.type, MGJ.Stakeholder)):
+        agent = next(g.objects(s, MGJ.stakeholderAgent), URIRef(""))
+        role = next(g.objects(s, MGJ.roleLabel), Literal(""))
+        resp = next(g.objects(s, MGJ.stakeholderResponsibilities), Literal(""))
+        table.add_row(_local_id_from_iri(str(s)), str(agent), str(role), str(resp))
+    console.print(table)
+
+
+@stakeholder_app.command("remove")
+def stakeholder_remove(
+    slug: str = typer.Argument(...),
+    local_id: str = typer.Argument(..., help="Numeric id from `stakeholder list`"),
+) -> None:
+    with with_mutation(slug, question=2) as g:
+        version = get_submission_version(g, slug)
+        node = _entity_iri(slug, version, "stakeholder", local_id)
+        if (node, RDF.type, MGJ.Stakeholder) not in g:
+            raise typer.BadParameter(f"stakeholder {local_id} not found")
+        sub = get_submission_iri(g, slug)
+        g.remove((sub, MGJ.hasStakeholder, node))
+        _remove_subject(g, node)
+    console.print(f"[yellow]– removed stakeholder {local_id}[/yellow]")
+
+
+# ---------------------------------------------------------------------------
+# Q3 — environmental factor
+# ---------------------------------------------------------------------------
+
+factor_app = typer.Typer(no_args_is_help=True, help="Q3 — environmental factors.")
+
+
+@factor_app.command("add")
+def factor_add(
+    slug: str = typer.Argument(...),
+    modality: str = typer.Option(
+        ..., "--modality", help="Law | Norms | Markets | Architecture"
+    ),
+    description: str = typer.Option(..., "--description", "-d"),
+) -> None:
+    if modality not in {"Law", "Norms", "Markets", "Architecture"}:
+        raise typer.BadParameter(
+            "modality must be one of: Law, Norms, Markets, Architecture"
+        )
+    with with_mutation(slug, question=3) as g:
+        sub = get_submission_iri(g, slug)
+        version = get_submission_version(g, slug)
+        lid = next_local_id(g, slug, version, "factor", "EnvironmentalFactor")
+        node = _entity_iri(slug, version, "factor", lid)
+        g.add((node, RDF.type, MGJ.EnvironmentalFactor))
+        g.add((node, MGJ.lessigModality, MGJ[modality]))
+        g.add((node, MGJ.factorDescription, Literal(description)))
+        g.add((sub, MGJ.hasEnvironmentalFactor, node))
+    console.print(f"[green]✓ added factor {lid}[/green]")
+
+
+@factor_app.command("list")
+def factor_list(slug: str = typer.Argument(...)) -> None:
+    g = load_submission_graph(slug)
+    table = Table("id", "modality", "description")
+    for s in sorted(g.subjects(RDF.type, MGJ.EnvironmentalFactor)):
+        mod = next(g.objects(s, MGJ.lessigModality), URIRef(""))
+        desc = next(g.objects(s, MGJ.factorDescription), Literal(""))
+        table.add_row(
+            _local_id_from_iri(str(s)),
+            str(mod).rsplit("#", 1)[-1],
+            str(desc),
+        )
+    console.print(table)
+
+
+@factor_app.command("remove")
+def factor_remove(
+    slug: str = typer.Argument(...), local_id: str = typer.Argument(...)
+) -> None:
+    with with_mutation(slug, question=3) as g:
+        version = get_submission_version(g, slug)
+        node = _entity_iri(slug, version, "factor", local_id)
+        if (node, RDF.type, MGJ.EnvironmentalFactor) not in g:
+            raise typer.BadParameter(f"factor {local_id} not found")
+        g.remove((get_submission_iri(g, slug), MGJ.hasEnvironmentalFactor, node))
+        _remove_subject(g, node)
+    console.print(f"[yellow]– removed factor {local_id}[/yellow]")
+
+
+# ---------------------------------------------------------------------------
+# Q4 — constitutional element
+# ---------------------------------------------------------------------------
+
+constitution_app = typer.Typer(
+    no_args_is_help=True, help="Q4 — constitutional elements."
+)
+
+_ELEMENT_TYPES = {"Bylaw", "Norm", "DecisionProcedure", "DisputeResolution", "AmendmentProcess"}
+
+
+@constitution_app.command("add")
+def constitution_add(
+    slug: str = typer.Argument(...),
+    label: str = typer.Option(..., "--label", "-l"),
+    description: str = typer.Option(..., "--description", "-d"),
+    element_type: str = typer.Option(
+        ..., "--type", help="Bylaw | Norm | DecisionProcedure | DisputeResolution | AmendmentProcess"
+    ),
+    source_url: str = typer.Option(None, "--source-url"),
+) -> None:
+    if element_type not in _ELEMENT_TYPES:
+        raise typer.BadParameter(f"--type must be one of {sorted(_ELEMENT_TYPES)}")
+    with with_mutation(slug, question=4) as g:
+        sub = get_submission_iri(g, slug)
+        version = get_submission_version(g, slug)
+        lid = next_local_id(g, slug, version, "constitution", "ConstitutionalElement")
+        node = _entity_iri(slug, version, "constitution", lid)
+        g.add((node, RDF.type, MGJ.ConstitutionalElement))
+        g.add((node, MGJ.elementLabel, Literal(label)))
+        g.add((node, MGJ.elementDescription, Literal(description)))
+        g.add((node, MGJ.elementType, MGJ[element_type]))
+        if source_url:
+            g.add((node, MGJ.elementSourceURL, Literal(source_url, datatype=XSD.anyURI)))
+        g.add((sub, MGJ.hasConstitutionalElement, node))
+    console.print(f"[green]✓ added constitutional element {lid}[/green]")
+
+
+@constitution_app.command("list")
+def constitution_list(slug: str = typer.Argument(...)) -> None:
+    g = load_submission_graph(slug)
+    table = Table("id", "type", "label", "description")
+    for s in sorted(g.subjects(RDF.type, MGJ.ConstitutionalElement)):
+        et = next(g.objects(s, MGJ.elementType), URIRef(""))
+        lab = next(g.objects(s, MGJ.elementLabel), Literal(""))
+        desc = next(g.objects(s, MGJ.elementDescription), Literal(""))
+        table.add_row(
+            _local_id_from_iri(str(s)),
+            str(et).rsplit("#", 1)[-1],
+            str(lab),
+            str(desc),
+        )
+    console.print(table)
+
+
+@constitution_app.command("remove")
+def constitution_remove(
+    slug: str = typer.Argument(...), local_id: str = typer.Argument(...)
+) -> None:
+    with with_mutation(slug, question=4) as g:
+        version = get_submission_version(g, slug)
+        node = _entity_iri(slug, version, "constitution", local_id)
+        if (node, RDF.type, MGJ.ConstitutionalElement) not in g:
+            raise typer.BadParameter(f"constitution {local_id} not found")
+        g.remove((get_submission_iri(g, slug), MGJ.hasConstitutionalElement, node))
+        _remove_subject(g, node)
+    console.print(f"[yellow]– removed constitution {local_id}[/yellow]")
+
+
+# ---------------------------------------------------------------------------
+# Q5 — field site
+# ---------------------------------------------------------------------------
+
+fieldsite_app = typer.Typer(no_args_is_help=True, help="Q5 — field sites.")
+
+
+@fieldsite_app.command("add")
+def fieldsite_add(
+    slug: str = typer.Argument(...),
+    label: str = typer.Option(..., "--label", "-l"),
+    url: str = typer.Option(None, "--url"),
+    description: str = typer.Option(None, "--description", "-d"),
+) -> None:
+    if url is None and not description:
+        raise typer.BadParameter("provide at least one of --url or --description")
+    with with_mutation(slug, question=5) as g:
+        sub = get_submission_iri(g, slug)
+        version = get_submission_version(g, slug)
+        lid = next_local_id(g, slug, version, "fieldsite", "FieldSite")
+        node = _entity_iri(slug, version, "fieldsite", lid)
+        g.add((node, RDF.type, MGJ.FieldSite))
+        g.add((node, MGJ.fieldSiteLabel, Literal(label)))
+        if url:
+            g.add((node, MGJ.fieldSiteURL, Literal(url, datatype=XSD.anyURI)))
+        if description:
+            g.add((node, MGJ.fieldSiteDescription, Literal(description)))
+        g.add((sub, MGJ.hasFieldSite, node))
+    console.print(f"[green]✓ added field site {lid}[/green]")
+
+
+@fieldsite_app.command("list")
+def fieldsite_list(slug: str = typer.Argument(...)) -> None:
+    g = load_submission_graph(slug)
+    table = Table("id", "label", "url", "description")
+    for s in sorted(g.subjects(RDF.type, MGJ.FieldSite)):
+        lab = next(g.objects(s, MGJ.fieldSiteLabel), Literal(""))
+        url = next(g.objects(s, MGJ.fieldSiteURL), Literal(""))
+        desc = next(g.objects(s, MGJ.fieldSiteDescription), Literal(""))
+        table.add_row(_local_id_from_iri(str(s)), str(lab), str(url), str(desc))
+    console.print(table)
+
+
+@fieldsite_app.command("remove")
+def fieldsite_remove(
+    slug: str = typer.Argument(...), local_id: str = typer.Argument(...)
+) -> None:
+    with with_mutation(slug, question=5) as g:
+        version = get_submission_version(g, slug)
+        node = _entity_iri(slug, version, "fieldsite", local_id)
+        if (node, RDF.type, MGJ.FieldSite) not in g:
+            raise typer.BadParameter(f"fieldsite {local_id} not found")
+        g.remove((get_submission_iri(g, slug), MGJ.hasFieldSite, node))
+        _remove_subject(g, node)
+    console.print(f"[yellow]– removed fieldsite {local_id}[/yellow]")
+
+
+# ---------------------------------------------------------------------------
+# Q7 — origin event
+# ---------------------------------------------------------------------------
+
+origin_app = typer.Typer(no_args_is_help=True, help="Q7 — origin events.")
+
+
+@origin_app.command("add")
+def origin_add(
+    slug: str = typer.Argument(...),
+    label: str = typer.Option(..., "--label", "-l"),
+    description: str = typer.Option(..., "--description", "-d"),
+    date_: str = typer.Option(None, "--date", help="ISO date"),
+    persons: str = typer.Option(
+        None, "--persons", help="Comma-separated person slugs"
+    ),
+    orgs: str = typer.Option(
+        None, "--orgs", help="Comma-separated organization slugs"
+    ),
+) -> None:
+    person_iris: list[URIRef] = []
+    org_iris: list[URIRef] = []
+    if persons:
+        person_iris = [URIRef(person_iri(s.strip())) for s in persons.split(",") if s.strip()]
+    if orgs:
+        org_iris = [URIRef(organization_iri(s.strip())) for s in orgs.split(",") if s.strip()]
+    if not person_iris and not org_iris:
+        raise typer.BadParameter("provide at least one of --persons or --orgs")
+
+    with with_mutation(slug, question=7) as g:
+        # Validate references resolve in shared/
+        for p in person_iris:
+            if (p, RDF.type, FOAF.Person) not in g:
+                raise typer.BadParameter(f"person not in shared/people.ttl: {p}")
+        for o in org_iris:
+            if (o, RDF.type, FOAF.Organization) not in g:
+                raise typer.BadParameter(f"org not in shared/organizations.ttl: {o}")
+        sub = get_submission_iri(g, slug)
+        version = get_submission_version(g, slug)
+        lid = next_local_id(g, slug, version, "origin", "OriginEvent")
+        node = _entity_iri(slug, version, "origin", lid)
+        g.add((node, RDF.type, MGJ.OriginEvent))
+        g.add((node, MGJ.originLabel, Literal(label)))
+        g.add((node, MGJ.originDescription, Literal(description)))
+        if date_:
+            DateT.fromisoformat(date_)  # validate
+            g.add((node, MGJ.originDate, Literal(date_, datatype=XSD.date)))
+        for p in person_iris:
+            g.add((node, MGJ.originParticipant, p))
+        for o in org_iris:
+            g.add((node, MGJ.originParticipant, o))
+        g.add((sub, MGJ.hasOriginEvent, node))
+    console.print(f"[green]✓ added origin event {lid}[/green]")
+
+
+@origin_app.command("list")
+def origin_list(slug: str = typer.Argument(...)) -> None:
+    g = load_submission_graph(slug)
+    table = Table("id", "label", "date", "participants")
+    for s in sorted(g.subjects(RDF.type, MGJ.OriginEvent)):
+        lab = next(g.objects(s, MGJ.originLabel), Literal(""))
+        d = next(g.objects(s, MGJ.originDate), Literal(""))
+        parts = ", ".join(
+            str(p).rsplit("/", 1)[-1] for p in g.objects(s, MGJ.originParticipant)
+        )
+        table.add_row(_local_id_from_iri(str(s)), str(lab), str(d), parts)
+    console.print(table)
+
+
+@origin_app.command("remove")
+def origin_remove(
+    slug: str = typer.Argument(...), local_id: str = typer.Argument(...)
+) -> None:
+    with with_mutation(slug, question=7) as g:
+        version = get_submission_version(g, slug)
+        node = _entity_iri(slug, version, "origin", local_id)
+        if (node, RDF.type, MGJ.OriginEvent) not in g:
+            raise typer.BadParameter(f"origin {local_id} not found")
+        g.remove((get_submission_iri(g, slug), MGJ.hasOriginEvent, node))
+        _remove_subject(g, node)
+    console.print(f"[yellow]– removed origin {local_id}[/yellow]")
+
+
+# ---------------------------------------------------------------------------
+# Q8 — evolution mechanism
+# ---------------------------------------------------------------------------
+
+evolution_app = typer.Typer(no_args_is_help=True, help="Q8 — evolution mechanisms.")
+
+
+@evolution_app.command("add")
+def evolution_add(
+    slug: str = typer.Argument(...),
+    label: str = typer.Option(..., "--label", "-l"),
+    description: str = typer.Option(..., "--description", "-d"),
+) -> None:
+    with with_mutation(slug, question=8) as g:
+        sub = get_submission_iri(g, slug)
+        version = get_submission_version(g, slug)
+        lid = next_local_id(g, slug, version, "evolution", "EvolutionMechanism")
+        node = _entity_iri(slug, version, "evolution", lid)
+        g.add((node, RDF.type, MGJ.EvolutionMechanism))
+        g.add((node, MGJ.mechanismLabel, Literal(label)))
+        g.add((node, MGJ.mechanismDescription, Literal(description)))
+        g.add((sub, MGJ.hasEvolutionMechanism, node))
+    console.print(f"[green]✓ added evolution mechanism {lid}[/green]")
+
+
+@evolution_app.command("list")
+def evolution_list(slug: str = typer.Argument(...)) -> None:
+    g = load_submission_graph(slug)
+    table = Table("id", "label", "description")
+    for s in sorted(g.subjects(RDF.type, MGJ.EvolutionMechanism)):
+        lab = next(g.objects(s, MGJ.mechanismLabel), Literal(""))
+        desc = next(g.objects(s, MGJ.mechanismDescription), Literal(""))
+        table.add_row(_local_id_from_iri(str(s)), str(lab), str(desc))
+    console.print(table)
+
+
+@evolution_app.command("remove")
+def evolution_remove(
+    slug: str = typer.Argument(...), local_id: str = typer.Argument(...)
+) -> None:
+    with with_mutation(slug, question=8) as g:
+        version = get_submission_version(g, slug)
+        node = _entity_iri(slug, version, "evolution", local_id)
+        if (node, RDF.type, MGJ.EvolutionMechanism) not in g:
+            raise typer.BadParameter(f"evolution {local_id} not found")
+        g.remove((get_submission_iri(g, slug), MGJ.hasEvolutionMechanism, node))
+        _remove_subject(g, node)
+    console.print(f"[yellow]– removed evolution {local_id}[/yellow]")
+
+
+# ---------------------------------------------------------------------------
+# Q9 — reference
+# ---------------------------------------------------------------------------
+
+reference_app = typer.Typer(no_args_is_help=True, help="Q9 — references.")
+
+
+@reference_app.command("add")
+def reference_add(
+    slug: str = typer.Argument(...),
+    title: str = typer.Option(..., "--title", "-t"),
+    identifier: str = typer.Option(
+        ..., "--identifier", "-i", help="DOI or canonical URL"
+    ),
+    creators: str = typer.Option(
+        None, "--creators", help="Comma-separated author names"
+    ),
+    date_: str = typer.Option(None, "--date"),
+) -> None:
+    with with_mutation(slug, question=9) as g:
+        sub = get_submission_iri(g, slug)
+        version = get_submission_version(g, slug)
+        lid = next_local_id(g, slug, version, "reference", "Reference")
+        node = _entity_iri(slug, version, "reference", lid)
+        g.add((node, RDF.type, MGJ.Reference))
+        g.add((node, DCTERMS.title, Literal(title)))
+        g.add((node, DCTERMS.identifier, Literal(identifier)))
+        if creators:
+            for c in [c.strip() for c in creators.split(",") if c.strip()]:
+                g.add((node, DCTERMS.creator, Literal(c)))
+        if date_:
+            g.add((node, DCTERMS.date, Literal(date_)))
+        g.add((sub, MGJ.hasReference, node))
+    console.print(f"[green]✓ added reference {lid}[/green]")
+
+
+@reference_app.command("list")
+def reference_list(slug: str = typer.Argument(...)) -> None:
+    g = load_submission_graph(slug)
+    table = Table("id", "title", "identifier", "date", "creators")
+    for s in sorted(g.subjects(RDF.type, MGJ.Reference)):
+        t = next(g.objects(s, DCTERMS.title), Literal(""))
+        i = next(g.objects(s, DCTERMS.identifier), Literal(""))
+        d = next(g.objects(s, DCTERMS.date), Literal(""))
+        cs = ", ".join(str(c) for c in g.objects(s, DCTERMS.creator))
+        table.add_row(_local_id_from_iri(str(s)), str(t), str(i), str(d), cs)
+    console.print(table)
+
+
+@reference_app.command("remove")
+def reference_remove(
+    slug: str = typer.Argument(...), local_id: str = typer.Argument(...)
+) -> None:
+    with with_mutation(slug, question=9) as g:
+        version = get_submission_version(g, slug)
+        node = _entity_iri(slug, version, "reference", local_id)
+        if (node, RDF.type, MGJ.Reference) not in g:
+            raise typer.BadParameter(f"reference {local_id} not found")
+        g.remove((get_submission_iri(g, slug), MGJ.hasReference, node))
+        _remove_subject(g, node)
+    console.print(f"[yellow]– removed reference {local_id}[/yellow]")
+
+
+# ---------------------------------------------------------------------------
+# LegalContext (cross-Q) — singleton per submission
+# ---------------------------------------------------------------------------
+
+legal_app = typer.Typer(no_args_is_help=True, help="Legal context (cross-Q).")
+
+_LEGAL_RELATIONSHIPS = {
+    "FiscalSponsor",
+    "LegalIncorporation",
+    "ParentOrganization",
+    "Incubator",
+    "Network",
+}
+
+
+@legal_app.command("set")
+def legal_set(
+    slug: str = typer.Argument(...),
+    host: str = typer.Option(..., "--host", help="Org slug from shared/organizations.ttl"),
+    relationship: str = typer.Option(
+        ..., "--relationship", help=" | ".join(sorted(_LEGAL_RELATIONSHIPS))
+    ),
+    description: str = typer.Option(..., "--description", "-d"),
+    funding_reference: str = typer.Option(None, "--funding-ref"),
+) -> None:
+    """Set or replace the LegalContext. Singleton per submission."""
+    if relationship not in _LEGAL_RELATIONSHIPS:
+        raise typer.BadParameter(
+            f"--relationship must be one of {sorted(_LEGAL_RELATIONSHIPS)}"
+        )
+    # Skip per-question validation (LegalContext spans Q3/Q4/Q7);
+    # system validation will run later.
+    with with_mutation(slug, question=None) as g:
+        sub = get_submission_iri(g, slug)
+        version = get_submission_version(g, slug)
+        host_iri = URIRef(organization_iri(host))
+        if (host_iri, RDF.type, FOAF.Organization) not in g:
+            raise typer.BadParameter(
+                f"org '{host}' not in shared/organizations.ttl"
+            )
+
+        # Remove any existing LegalContext for this submission.
+        for old in list(g.objects(sub, MGJ.operatesUnder)):
+            g.remove((sub, MGJ.operatesUnder, old))
+            _remove_subject(g, old)
+
+        node = _entity_iri(slug, version, "legal", "1")
+        g.add((node, RDF.type, MGJ.LegalContext))
+        g.add((node, MGJ.hostOrganization, host_iri))
+        g.add((node, MGJ.legalRelationship, MGJ[relationship]))
+        g.add((node, MGJ.legalContextDescription, Literal(description)))
+        if funding_reference:
+            g.add((node, MGJ.fundingReference, Literal(funding_reference)))
+        g.add((sub, MGJ.operatesUnder, node))
+    console.print("[green]✓ legal context set[/green]")
+
+
+@legal_app.command("show")
+def legal_show(slug: str = typer.Argument(...)) -> None:
+    g = load_submission_graph(slug)
+    sub = get_submission_iri(g, slug)
+    lc = next(g.objects(sub, MGJ.operatesUnder), None)
+    if lc is None:
+        console.print("[dim]no legal context set[/dim]")
+        return
+    host = next(g.objects(lc, MGJ.hostOrganization), URIRef(""))
+    rel = next(g.objects(lc, MGJ.legalRelationship), URIRef(""))
+    desc = next(g.objects(lc, MGJ.legalContextDescription), Literal(""))
+    funding = next(g.objects(lc, MGJ.fundingReference), Literal(""))
+    table = Table("field", "value")
+    table.add_row("host", str(host).rsplit("/", 1)[-1])
+    table.add_row("relationship", str(rel).rsplit("#", 1)[-1])
+    table.add_row("description", str(desc))
+    if funding:
+        table.add_row("funding ref", str(funding))
+    console.print(table)
+
+
+@legal_app.command("clear")
+def legal_clear(slug: str = typer.Argument(...)) -> None:
+    with with_mutation(slug, question=None) as g:
+        sub = get_submission_iri(g, slug)
+        for old in list(g.objects(sub, MGJ.operatesUnder)):
+            g.remove((sub, MGJ.operatesUnder, old))
+            _remove_subject(g, old)
+    console.print("[yellow]– legal context cleared[/yellow]")
+
+
+# ---------------------------------------------------------------------------
+# Q6 — author disclosure (singleton, lives on Submission)
+# ---------------------------------------------------------------------------
+
+author_app = typer.Typer(no_args_is_help=True, help="Q6 — author disclosure.")
+
+
+@author_app.command("set")
+def author_set(
+    slug: str = typer.Argument(...),
+    person: str = typer.Option(..., "--person", help="Slug from shared/people.ttl"),
+    role: str = typer.Option(None, "--role", help="Author's role within the institution"),
+    disclosure: str = typer.Option(None, "--disclosure", help="Disclosure narrative"),
+) -> None:
+    with with_mutation(slug, question=6) as g:
+        sub = get_submission_iri(g, slug)
+        person_uri = URIRef(person_iri(person))
+        if (person_uri, RDF.type, FOAF.Person) not in g:
+            raise typer.BadParameter(
+                f"person '{person}' not in shared/people.ttl"
+            )
+        g.remove((sub, MGJ.authoredBy, None))
+        g.add((sub, MGJ.authoredBy, person_uri))
+        if role is not None:
+            g.remove((sub, MGJ.authorRole, None))
+            g.add((sub, MGJ.authorRole, Literal(role)))
+        if disclosure is not None:
+            g.remove((sub, MGJ.authorDisclosure, None))
+            g.add((sub, MGJ.authorDisclosure, Literal(disclosure)))
+    console.print("[green]✓ author disclosure set[/green]")

--- a/src/mgj/commands/extract.py
+++ b/src/mgj/commands/extract.py
@@ -1,0 +1,73 @@
+"""
+mgj.commands.extract
+--------------------
+``mgj extract <slug> [-q N] [--force]``
+
+Runs the LLM-driven extractor over the submission's input.md, emitting
+typed RDF triples into instance.ttl. The default backend is
+``ClaudeBackend``; tests inject ``MockLLMBackend`` via the
+``mgj.commands.extract.backend_factory`` hook.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import typer
+
+from mgj.commands._common import console, err_console
+from mgj.parser.backends import ClaudeBackend, LLMBackend
+from mgj.parser.extract import run_extraction
+from mgj.parser.schemas import QUESTIONS_WITH_ENTITIES
+
+app = typer.Typer(no_args_is_help=True, help="LLM-driven extraction.")
+
+
+def _default_backend_factory() -> LLMBackend:
+    """Default to Claude. Override via monkeypatching for tests."""
+    return ClaudeBackend()
+
+
+backend_factory: Callable[[], LLMBackend] = _default_backend_factory
+"""Module-level hook tests reassign to inject a mock backend."""
+
+
+@app.command()
+def extract(
+    slug: str = typer.Argument(..., help="Submission slug"),
+    question: int = typer.Option(
+        None, "--question", "-q", help="Extract a specific question (default: all)"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Re-extract even for already-affirmed questions"
+    ),
+) -> None:
+    if question is not None and question not in QUESTIONS_WITH_ENTITIES:
+        raise typer.BadParameter(
+            f"--question must be one of {QUESTIONS_WITH_ENTITIES}"
+        )
+
+    backend = backend_factory()
+    try:
+        result = run_extraction(
+            slug,
+            backend=backend,
+            questions=[question] if question is not None else None,
+            force=force,
+        )
+    except FileNotFoundError as e:
+        err_console.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1)
+
+    if result.extracted_questions:
+        qs = ", ".join(f"Q{q}" for q in result.extracted_questions)
+        console.print(f"[green]✓ extracted[/green] {qs}")
+    if result.cache_hits:
+        qs = ", ".join(f"Q{q}" for q in result.cache_hits)
+        console.print(f"[dim]cache hit:[/dim] {qs}")
+    if result.skipped_affirmed:
+        qs = ", ".join(f"Q{q}" for q in result.skipped_affirmed)
+        console.print(
+            f"[yellow]skipped affirmed:[/yellow] {qs} "
+            "(use --force or `mgj unaffirm -q N` first)"
+        )

--- a/src/mgj/commands/lifecycle.py
+++ b/src/mgj/commands/lifecycle.py
@@ -1,0 +1,231 @@
+"""
+mgj.commands.lifecycle
+----------------------
+Lifecycle commands: init, status, validate, canonicalize, narrative.
+"""
+
+from __future__ import annotations
+
+from datetime import date as DateT
+from pathlib import Path
+
+import typer
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import RDF, XSD
+from rich.table import Table
+
+from mgj.canonicalize import canonicalize_file, canonicalize_turtle
+from mgj.commands._common import (
+    ExtractionTrace,
+    console,
+    err_console,
+    get_submission_iri,
+    get_submission_version,
+    load_submission_graph,
+    load_trace,
+    now_iso,
+    report_validation,
+    save_submission_graph_separating_shared,
+    save_trace,
+    trace_path,
+    with_mutation,
+)
+from mgj.graph import submission_dir, submission_instance_path
+from mgj.namespaces import MGJ, institution_iri, submission_iri
+from mgj.validate import validate
+
+app = typer.Typer(no_args_is_help=True, help="Lifecycle commands.")
+
+INPUT_TEMPLATE = """# {name}
+
+*Author's prose answering the institutional catechism. The CLI parser
+extracts typed RDF from this file; you confirm the extraction Q-by-Q
+before compilation.*
+
+## 1. What is the institution's purpose?
+
+(Write 75–110 words.)
+
+## 2. Who are the stakeholders and what are their roles?
+
+## 3. What environmental factors shape the institution?
+
+## 4. What constitutes the institution's constitution?
+
+## 5. Where are the field sites?
+
+## 6. What is your relationship to the institution?
+
+## 7. How and when did the institution emerge?
+
+## 8. How does the institution evolve?
+
+## 9. What references support this documentation?
+"""
+
+
+@app.command()
+def init(
+    slug: str = typer.Argument(..., help="URL-safe submission slug, e.g. 'metagov-journal'"),
+    name: str = typer.Option(..., "--name", "-n", help="Institution display name"),
+    version: str = typer.Option("1.0.0", "--version", "-v", help="Submission version"),
+    submission_date: str = typer.Option(
+        None, "--date", "-d", help="ISO date (defaults to today)"
+    ),
+) -> None:
+    """Scaffold a new submission directory: input.md, instance.ttl skeleton,
+    and extraction-trace.json. Refuses to overwrite an existing submission
+    (instance.ttl present); coexists with other files (e.g. manifest.yml,
+    legacy specification.md)."""
+    target = submission_dir(slug)
+    if (target / "instance.ttl").exists():
+        err_console.print(
+            f"[red]submission '{slug}' already initialized "
+            f"(instance.ttl exists at {target})[/red]"
+        )
+        raise typer.Exit(code=1)
+    target.mkdir(parents=True, exist_ok=True)
+
+    # input.md — only write if not already present.
+    input_path = target / "input.md"
+    if not input_path.exists():
+        input_path.write_text(INPUT_TEMPLATE.format(name=name))
+
+    # instance.ttl skeleton: just the Submission and Institution stubs.
+    g = Graph()
+    inst = URIRef(institution_iri(slug))
+    sub = URIRef(submission_iri(slug, version))
+    g.add((inst, RDF.type, MGJ.Institution))
+    g.add((inst, MGJ.institutionName, Literal(name)))
+    g.add((sub, RDF.type, MGJ.Submission))
+    g.add((sub, MGJ.documents, inst))
+    g.add((sub, MGJ.submissionVersion, Literal(version)))
+    today = submission_date or DateT.today().isoformat()
+    g.add((sub, MGJ.submissionDate, Literal(today, datatype=XSD.date)))
+
+    save_submission_graph_separating_shared(g, slug)
+
+    # Trace skeleton
+    save_trace(
+        ExtractionTrace(
+            slug=slug,
+            version=version,
+            affirmed_questions={i: None for i in range(1, 10)},
+            extractions=[],
+        )
+    )
+
+    console.print(f"[green]✓ initialized[/green] submissions/{slug}/")
+    console.print(f"  input.md, instance.ttl, extraction-trace.json")
+
+
+@app.command()
+def status(
+    slug: str = typer.Argument(..., help="Submission slug"),
+) -> None:
+    """Report instance state: version, entity counts, per-Q affirmation status."""
+    g = load_submission_graph(slug)
+    sub = get_submission_iri(g, slug)
+    version = get_submission_version(g, slug)
+    trace = load_trace(slug)
+
+    console.print(f"[bold]{slug}[/bold] v{version}")
+    console.print(f"  IRI: {sub}")
+
+    counts = _entity_counts(g)
+    table = Table("question", "entity", "count", "affirmed")
+    rows = [
+        (1, "(narrative)", _has_narrative(g, sub, "q1Narrative"), trace.affirmed_questions.get(1)),
+        (2, "stakeholders", counts["Stakeholder"], trace.affirmed_questions.get(2)),
+        (3, "environmental factors", counts["EnvironmentalFactor"], trace.affirmed_questions.get(3)),
+        (4, "constitutional elements", counts["ConstitutionalElement"], trace.affirmed_questions.get(4)),
+        (5, "field sites", counts["FieldSite"], trace.affirmed_questions.get(5)),
+        (6, "(author disclosure)", _has_narrative(g, sub, "q6Narrative"), trace.affirmed_questions.get(6)),
+        (7, "origin events", counts["OriginEvent"], trace.affirmed_questions.get(7)),
+        (8, "evolution mechanisms", counts["EvolutionMechanism"], trace.affirmed_questions.get(8)),
+        (9, "references", counts["Reference"], trace.affirmed_questions.get(9)),
+    ]
+    for q, label, count, affirmed in rows:
+        table.add_row(
+            f"Q{q}",
+            label,
+            str(count),
+            affirmed or "[dim]—[/dim]",
+        )
+    console.print(table)
+
+
+def _entity_counts(g: Graph) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for cls in [
+        "Stakeholder",
+        "EnvironmentalFactor",
+        "ConstitutionalElement",
+        "FieldSite",
+        "OriginEvent",
+        "EvolutionMechanism",
+        "Reference",
+        "LegalContext",
+    ]:
+        out[cls] = sum(1 for _ in g.subjects(predicate=RDF.type, object=MGJ[cls]))
+    return out
+
+
+def _has_narrative(g: Graph, sub: URIRef, prop: str) -> str:
+    """Return 'set' or '—'."""
+    return "set" if any(g.objects(subject=sub, predicate=MGJ[prop])) else "—"
+
+
+@app.command(name="validate")
+def validate_cmd(
+    slug: str = typer.Argument(..., help="Submission slug"),
+    question: int = typer.Option(
+        None, "--question", "-q", help="Validate against Qi inner-loop shapes only"
+    ),
+) -> None:
+    """Run SHACL validation. Defaults to system shapes; pass -q N for per-Q."""
+    g = load_submission_graph(slug)
+    if question is not None:
+        report = validate(g, mode="per_question", question=question)
+        report_validation(report, label=f"Q{question} per-question")
+    else:
+        report = validate(g, mode="system")
+        report_validation(report, label="system")
+    if not report.conforms:
+        raise typer.Exit(code=1)
+
+
+@app.command()
+def canonicalize(
+    slug: str = typer.Argument(..., help="Submission slug"),
+) -> None:
+    """Re-normalize instance.ttl into canonical form. Idempotent."""
+    p = submission_instance_path(slug)
+    if not p.exists():
+        err_console.print(f"[red]no instance.ttl at {p}[/red]")
+        raise typer.Exit(code=1)
+    changed = canonicalize_file(p)
+    if changed:
+        console.print(f"[yellow]canonicalized[/yellow] {p}")
+    else:
+        console.print(f"[green]already canonical[/green] {p}")
+
+
+@app.command()
+def narrative(
+    slug: str = typer.Argument(..., help="Submission slug"),
+    question: int = typer.Option(..., "--question", "-q", help="Question number 1..9"),
+    text: str = typer.Argument(..., help="Narrative text"),
+) -> None:
+    """Set the narrative for a catechism question. Replaces any existing
+    narrative for that question."""
+    if not 1 <= question <= 9:
+        raise typer.BadParameter("question must be 1..9")
+    if not text.strip():
+        raise typer.BadParameter("narrative must be non-empty")
+    with with_mutation(slug, question=question) as g:
+        sub = get_submission_iri(g, slug)
+        prop = MGJ[f"q{question}Narrative"]
+        g.remove((sub, prop, None))
+        g.add((sub, prop, Literal(text)))
+    console.print(f"[green]✓ Q{question} narrative set[/green]")

--- a/src/mgj/commands/registries.py
+++ b/src/mgj/commands/registries.py
@@ -1,0 +1,145 @@
+"""
+mgj.commands.registries
+-----------------------
+CLI commands for the shared people and organizations registries.
+
+Both registries support add / set / list. Removal is intentionally not
+supported — references from active submissions could break, and stale
+entries do no harm. To retire a person, leave their record in place.
+"""
+
+from __future__ import annotations
+
+import typer
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import FOAF, RDF, XSD
+from rich.table import Table
+
+from mgj.commands._common import (
+    console,
+    err_console,
+    load_shared_registry,
+    save_shared_registry,
+)
+from mgj.namespaces import organization_iri, person_iri
+
+people_app = typer.Typer(no_args_is_help=True, help="Shared people registry.")
+orgs_app = typer.Typer(no_args_is_help=True, help="Shared organizations registry.")
+
+
+# ---------------------------------------------------------------------------
+# people
+# ---------------------------------------------------------------------------
+
+
+@people_app.command("add")
+def people_add(
+    slug: str = typer.Argument(..., help="URL-safe slug, e.g. 'michael-zargham'"),
+    name: str = typer.Option(..., "--name", "-n", help="Display name"),
+    homepage: str = typer.Option(None, "--homepage", help="Homepage URL"),
+) -> None:
+    """Add a foaf:Person to shared/people.ttl. Errors if the slug exists."""
+    g = load_shared_registry("people.ttl")
+    iri = URIRef(person_iri(slug))
+    if (iri, RDF.type, FOAF.Person) in g:
+        err_console.print(f"[red]person '{slug}' already exists; use `set` to update[/red]")
+        raise typer.Exit(code=1)
+    g.add((iri, RDF.type, FOAF.Person))
+    g.add((iri, FOAF.name, Literal(name)))
+    if homepage:
+        g.add((iri, FOAF.homepage, Literal(homepage, datatype=XSD.anyURI)))
+    save_shared_registry(g, "people.ttl")
+    console.print(f"[green]✓ added person[/green] {slug} → {iri}")
+
+
+@people_app.command("set")
+def people_set(
+    slug: str = typer.Argument(...),
+    name: str = typer.Option(None, "--name", "-n"),
+    homepage: str = typer.Option(None, "--homepage"),
+) -> None:
+    """Update an existing person. Pass only the fields you want to change."""
+    g = load_shared_registry("people.ttl")
+    iri = URIRef(person_iri(slug))
+    if (iri, RDF.type, FOAF.Person) not in g:
+        err_console.print(f"[red]person '{slug}' not found[/red]")
+        raise typer.Exit(code=1)
+    if name is not None:
+        g.remove((iri, FOAF.name, None))
+        g.add((iri, FOAF.name, Literal(name)))
+    if homepage is not None:
+        g.remove((iri, FOAF.homepage, None))
+        g.add((iri, FOAF.homepage, Literal(homepage, datatype=XSD.anyURI)))
+    save_shared_registry(g, "people.ttl")
+    console.print(f"[green]✓ updated person[/green] {slug}")
+
+
+@people_app.command("list")
+def people_list() -> None:
+    """List all people in the shared registry."""
+    g = load_shared_registry("people.ttl")
+    table = Table("slug", "name", "homepage")
+    for s in sorted(g.subjects(RDF.type, FOAF.Person)):
+        slug = str(s).rsplit("/", 1)[-1]
+        name = next(g.objects(s, FOAF.name), Literal(""))
+        homepage = next(g.objects(s, FOAF.homepage), Literal(""))
+        table.add_row(slug, str(name), str(homepage))
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# orgs
+# ---------------------------------------------------------------------------
+
+
+@orgs_app.command("add")
+def orgs_add(
+    slug: str = typer.Argument(...),
+    name: str = typer.Option(..., "--name", "-n"),
+    homepage: str = typer.Option(None, "--homepage"),
+) -> None:
+    """Add a foaf:Organization to shared/organizations.ttl."""
+    g = load_shared_registry("organizations.ttl")
+    iri = URIRef(organization_iri(slug))
+    if (iri, RDF.type, FOAF.Organization) in g:
+        err_console.print(f"[red]org '{slug}' already exists; use `set` to update[/red]")
+        raise typer.Exit(code=1)
+    g.add((iri, RDF.type, FOAF.Organization))
+    g.add((iri, FOAF.name, Literal(name)))
+    if homepage:
+        g.add((iri, FOAF.homepage, Literal(homepage, datatype=XSD.anyURI)))
+    save_shared_registry(g, "organizations.ttl")
+    console.print(f"[green]✓ added org[/green] {slug} → {iri}")
+
+
+@orgs_app.command("set")
+def orgs_set(
+    slug: str = typer.Argument(...),
+    name: str = typer.Option(None, "--name", "-n"),
+    homepage: str = typer.Option(None, "--homepage"),
+) -> None:
+    g = load_shared_registry("organizations.ttl")
+    iri = URIRef(organization_iri(slug))
+    if (iri, RDF.type, FOAF.Organization) not in g:
+        err_console.print(f"[red]org '{slug}' not found[/red]")
+        raise typer.Exit(code=1)
+    if name is not None:
+        g.remove((iri, FOAF.name, None))
+        g.add((iri, FOAF.name, Literal(name)))
+    if homepage is not None:
+        g.remove((iri, FOAF.homepage, None))
+        g.add((iri, FOAF.homepage, Literal(homepage, datatype=XSD.anyURI)))
+    save_shared_registry(g, "organizations.ttl")
+    console.print(f"[green]✓ updated org[/green] {slug}")
+
+
+@orgs_app.command("list")
+def orgs_list() -> None:
+    g = load_shared_registry("organizations.ttl")
+    table = Table("slug", "name", "homepage")
+    for s in sorted(g.subjects(RDF.type, FOAF.Organization)):
+        slug = str(s).rsplit("/", 1)[-1]
+        name = next(g.objects(s, FOAF.name), Literal(""))
+        homepage = next(g.objects(s, FOAF.homepage), Literal(""))
+        table.add_row(slug, str(name), str(homepage))
+    console.print(table)

--- a/src/mgj/compilers/catechism.py
+++ b/src/mgj/compilers/catechism.py
@@ -1,0 +1,451 @@
+"""
+mgj.compilers.catechism
+-----------------------
+Render a single submission graph into a published Markdown article.
+
+Determinism invariant: for a fixed instance.ttl + compiler version, the
+output bytes are identical across runs. The wiki compiler exposes the
+same property over the full graph.
+
+Strategy: SPARQL-driven extraction with explicit ORDER BY, then Python
+post-sort by local-id integer where applicable so e.g. "stakeholder/2"
+precedes "stakeholder/10". Markdown rendering is hand-coded rather than
+templated to keep the output easy to inspect and diff.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rdflib import Graph
+
+from mgj.graph import load_instance, sparql_select
+from mgj.namespaces import SPARQL_PREFIXES
+
+COMPILER_VERSION = "0.1.0"
+COMPILER_ID = "mgj.compilers.catechism"
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry points
+# ---------------------------------------------------------------------------
+
+
+def compile_submission_file(instance_path: str | Path) -> str:
+    """Load ``instance_path`` and return the compiled Markdown string."""
+    g = load_instance(instance_path)
+    return compile_submission(g)
+
+
+def compile_submission(g: Graph) -> str:
+    """Render the single mgj:Submission in ``g`` into a Markdown article."""
+    sub = _single_submission_iri(g)
+    inst_iri, inst_name = _institution_for(g, sub)
+    version = _scalar(g, sub, "submissionVersion") or ""
+    s_date = _scalar(g, sub, "submissionDate") or ""
+
+    lines: list[str] = []
+    lines.append(f"# {inst_name}")
+    lines.append("")
+    lines.append(f"*Submission v{version} — {s_date}*")
+    lines.append("")
+    lines.append(f"<!-- compiler: {COMPILER_ID} v{COMPILER_VERSION} -->")
+    lines.append("")
+
+    lines.extend(_render_q1(g, sub))
+    lines.extend(_render_q2(g, sub))
+    lines.extend(_render_q3(g, sub))
+    lines.extend(_render_q4(g, sub))
+    lines.extend(_render_q5(g, sub))
+    lines.extend(_render_q6(g, sub))
+    lines.extend(_render_q7(g, sub))
+    lines.extend(_render_q8(g, sub))
+    lines.extend(_render_legal_context(g, sub))
+    lines.extend(_render_q9(g, sub))
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Question renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_q1(g: Graph, sub: str) -> list[str]:
+    out = ["## 1. Purpose", ""]
+    nar = _scalar(g, sub, "q1Narrative")
+    out.append(nar or "*(narrative not yet provided)*")
+    out.append("")
+    return out
+
+
+def _render_q2(g: Graph, sub: str) -> list[str]:
+    out = ["## 2. Stakeholders and roles", ""]
+    nar = _scalar(g, sub, "q2Narrative")
+    out.append(nar or "*(narrative not yet provided)*")
+    out.append("")
+
+    rows = _ordered_select(
+        g,
+        f"""
+        SELECT ?s ?roleLabel ?agentName ?responsibilities
+        WHERE {{
+            <{sub}> mgj:hasStakeholder ?s .
+            ?s mgj:roleLabel ?roleLabel .
+            OPTIONAL {{ ?s mgj:stakeholderAgent ?agent . ?agent foaf:name ?agentName }}
+            OPTIONAL {{ ?s mgj:stakeholderResponsibilities ?responsibilities }}
+        }}
+        """,
+        sort_key=lambda r: _local_id_int(r["s"]),
+    )
+    if rows:
+        out.append("### Stakeholders")
+        out.append("")
+        for r in rows:
+            line = f"- **{r['roleLabel']}**"
+            if r["agentName"]:
+                line += f": {r['agentName']}"
+            if r["responsibilities"]:
+                line += f" — {r['responsibilities']}"
+            out.append(line)
+        out.append("")
+    return out
+
+
+def _render_q3(g: Graph, sub: str) -> list[str]:
+    out = ["## 3. Environmental factors", ""]
+    nar = _scalar(g, sub, "q3Narrative")
+    out.append(nar or "*(narrative not yet provided)*")
+    out.append("")
+
+    rows = _ordered_select(
+        g,
+        f"""
+        SELECT ?s ?modality ?description
+        WHERE {{
+            <{sub}> mgj:hasEnvironmentalFactor ?s .
+            ?s mgj:lessigModality ?modality ;
+               mgj:factorDescription ?description .
+        }}
+        """,
+        sort_key=lambda r: (_short_concept(r["modality"]), _local_id_int(r["s"])),
+    )
+    if rows:
+        # Group by modality, preserving the canonical Law/Norms/Markets/Architecture order.
+        groups: dict[str, list[dict]] = {}
+        for r in rows:
+            groups.setdefault(_short_concept(r["modality"]), []).append(r)
+        for modality in ["Law", "Norms", "Markets", "Architecture"]:
+            if modality not in groups:
+                continue
+            out.append(f"### {modality}")
+            out.append("")
+            for r in groups[modality]:
+                out.append(f"- {r['description']}")
+            out.append("")
+    return out
+
+
+def _render_q4(g: Graph, sub: str) -> list[str]:
+    out = ["## 4. Constitution", ""]
+    nar = _scalar(g, sub, "q4Narrative")
+    out.append(nar or "*(narrative not yet provided)*")
+    out.append("")
+
+    rows = _ordered_select(
+        g,
+        f"""
+        SELECT ?s ?label ?description ?type ?sourceURL
+        WHERE {{
+            <{sub}> mgj:hasConstitutionalElement ?s .
+            ?s mgj:elementLabel ?label ;
+               mgj:elementDescription ?description ;
+               mgj:elementType ?type .
+            OPTIONAL {{ ?s mgj:elementSourceURL ?sourceURL }}
+        }}
+        """,
+        sort_key=lambda r: (_short_concept(r["type"]), _local_id_int(r["s"])),
+    )
+    if rows:
+        groups: dict[str, list[dict]] = {}
+        for r in rows:
+            groups.setdefault(_short_concept(r["type"]), []).append(r)
+        for kind in [
+            "Bylaw",
+            "Norm",
+            "DecisionProcedure",
+            "DisputeResolution",
+            "AmendmentProcess",
+        ]:
+            if kind not in groups:
+                continue
+            out.append(f"### {_pretty_concept(kind)}")
+            out.append("")
+            for r in groups[kind]:
+                line = f"- **{r['label']}**: {r['description']}"
+                if r["sourceURL"]:
+                    line += f" *([source]({r['sourceURL']}))*"
+                out.append(line)
+            out.append("")
+    return out
+
+
+def _render_q5(g: Graph, sub: str) -> list[str]:
+    out = ["## 5. Field sites", ""]
+    nar = _scalar(g, sub, "q5Narrative")
+    out.append(nar or "*(narrative not yet provided)*")
+    out.append("")
+    rows = _ordered_select(
+        g,
+        f"""
+        SELECT ?s ?label ?url ?description
+        WHERE {{
+            <{sub}> mgj:hasFieldSite ?s .
+            ?s mgj:fieldSiteLabel ?label .
+            OPTIONAL {{ ?s mgj:fieldSiteURL ?url }}
+            OPTIONAL {{ ?s mgj:fieldSiteDescription ?description }}
+        }}
+        """,
+        sort_key=lambda r: _local_id_int(r["s"]),
+    )
+    for r in rows:
+        title = f"[{r['label']}]({r['url']})" if r["url"] else f"**{r['label']}**"
+        line = f"- {title}"
+        if r["description"]:
+            line += f" — {r['description']}"
+        out.append(line)
+    out.append("")
+    return out
+
+
+def _render_q6(g: Graph, sub: str) -> list[str]:
+    out = ["## 6. Author relationship", ""]
+    nar = _scalar(g, sub, "q6Narrative")
+    out.append(nar or "*(narrative not yet provided)*")
+    out.append("")
+    rows = _ordered_select(
+        g,
+        f"""
+        SELECT ?name
+        WHERE {{
+            <{sub}> mgj:authoredBy ?p . ?p foaf:name ?name .
+        }}
+        """,
+        sort_key=lambda r: r["name"],
+    )
+    role = _scalar(g, sub, "authorRole")
+    disclosure = _scalar(g, sub, "authorDisclosure")
+    if rows:
+        author_line = f"*Authored by **{rows[0]['name']}**"
+        if role:
+            author_line += f" — {role}"
+        author_line += ".*"
+        out.append(author_line)
+        out.append("")
+    if disclosure:
+        out.append(f"*Disclosure:* {disclosure}")
+        out.append("")
+    return out
+
+
+def _render_q7(g: Graph, sub: str) -> list[str]:
+    out = ["## 7. Origins", ""]
+    nar = _scalar(g, sub, "q7Narrative")
+    out.append(nar or "*(narrative not yet provided)*")
+    out.append("")
+    events = _ordered_select(
+        g,
+        f"""
+        SELECT ?s ?label ?description ?date
+        WHERE {{
+            <{sub}> mgj:hasOriginEvent ?s .
+            ?s mgj:originLabel ?label ;
+               mgj:originDescription ?description .
+            OPTIONAL {{ ?s mgj:originDate ?date }}
+        }}
+        """,
+        sort_key=lambda r: (r["date"] or "", _local_id_int(r["s"])),
+    )
+    for ev in events:
+        # Resolve participants in a deterministic order
+        parts = sparql_select(
+            g,
+            f"""
+            SELECT ?name WHERE {{
+                <{ev['s']}> mgj:originParticipant ?p . ?p foaf:name ?name .
+            }} ORDER BY ?name
+            """,
+        )
+        names = ", ".join(p["name"] for p in parts)
+        date = f" ({ev['date']})" if ev["date"] else ""
+        line = f"- **{ev['label']}**{date}: {ev['description']}"
+        if names:
+            line += f" — *participants: {names}*"
+        out.append(line)
+    out.append("")
+    return out
+
+
+def _render_q8(g: Graph, sub: str) -> list[str]:
+    out = ["## 8. Evolution", ""]
+    nar = _scalar(g, sub, "q8Narrative")
+    out.append(nar or "*(narrative not yet provided)*")
+    out.append("")
+    rows = _ordered_select(
+        g,
+        f"""
+        SELECT ?s ?label ?description
+        WHERE {{
+            <{sub}> mgj:hasEvolutionMechanism ?s .
+            ?s mgj:mechanismLabel ?label ;
+               mgj:mechanismDescription ?description .
+        }}
+        """,
+        sort_key=lambda r: _local_id_int(r["s"]),
+    )
+    for r in rows:
+        out.append(f"- **{r['label']}**: {r['description']}")
+    out.append("")
+    return out
+
+
+def _render_q9(g: Graph, sub: str) -> list[str]:
+    out = ["## 9. References", ""]
+    nar = _scalar(g, sub, "q9Narrative")
+    if nar:
+        out.append(nar)
+        out.append("")
+    rows = _ordered_select(
+        g,
+        f"""
+        SELECT ?s ?title ?identifier ?date
+        WHERE {{
+            <{sub}> mgj:hasReference ?s .
+            ?s dcterms:title ?title ;
+               dcterms:identifier ?identifier .
+            OPTIONAL {{ ?s dcterms:date ?date }}
+        }}
+        """,
+        sort_key=lambda r: _local_id_int(r["s"]),
+    )
+    for i, r in enumerate(rows, 1):
+        creators = sparql_select(
+            g,
+            f"""
+            SELECT ?c WHERE {{ <{r['s']}> dcterms:creator ?c }} ORDER BY ?c
+            """,
+        )
+        names = ", ".join(c["c"] for c in creators)
+        date = f" ({r['date']})" if r["date"] else ""
+        prefix = f"{names}{date}" if names else (r["date"] or "")
+        title_link = f"[{r['title']}]({r['identifier']})"
+        if prefix:
+            out.append(f"{i}. {prefix}. {title_link}")
+        else:
+            out.append(f"{i}. {title_link}")
+    out.append("")
+    return out
+
+
+def _render_legal_context(g: Graph, sub: str) -> list[str]:
+    rows = sparql_select(
+        g,
+        f"""
+        SELECT ?lc ?relationship ?description ?fundingRef ?hostName WHERE {{
+            <{sub}> mgj:operatesUnder ?lc .
+            ?lc mgj:legalRelationship ?relationship ;
+                mgj:legalContextDescription ?description ;
+                mgj:hostOrganization ?host .
+            ?host foaf:name ?hostName .
+            OPTIONAL {{ ?lc mgj:fundingReference ?fundingRef }}
+        }}
+        """,
+    )
+    if not rows:
+        return []
+    r = rows[0]
+    out = ["## Legal context", ""]
+    relationship = _short_concept(r["relationship"])
+    relationship_pretty = _pretty_concept(relationship)
+    out.append(
+        f"*Operates under **{r['hostName']}** as {relationship_pretty.lower()}.*"
+    )
+    out.append("")
+    out.append(r["description"])
+    if r["fundingRef"]:
+        out.append("")
+        out.append(f"*Funding reference:* `{r['fundingRef']}`")
+    out.append("")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# SPARQL + sorting helpers
+# ---------------------------------------------------------------------------
+
+
+def _ordered_select(g: Graph, query: str, *, sort_key) -> list[dict[str, str]]:
+    rows = sparql_select(g, query)
+    return sorted(rows, key=sort_key)
+
+
+def _scalar(g: Graph, subject: str, prop: str) -> str | None:
+    rows = sparql_select(
+        g, f"SELECT ?v WHERE {{ <{subject}> mgj:{prop} ?v }} LIMIT 1"
+    )
+    return rows[0]["v"] if rows else None
+
+
+def _single_submission_iri(g: Graph) -> str:
+    rows = sparql_select(g, "SELECT ?s WHERE { ?s a mgj:Submission } ORDER BY ?s")
+    if len(rows) != 1:
+        raise ValueError(
+            f"expected exactly one mgj:Submission in graph; found {len(rows)}"
+        )
+    return rows[0]["s"]
+
+
+def _institution_for(g: Graph, sub: str) -> tuple[str, str]:
+    rows = sparql_select(
+        g,
+        f"""
+        SELECT ?inst ?name WHERE {{
+            <{sub}> mgj:documents ?inst . ?inst mgj:institutionName ?name .
+        }}
+        """,
+    )
+    if not rows:
+        raise ValueError(f"submission {sub} has no institution name")
+    return rows[0]["inst"], rows[0]["name"]
+
+
+def _local_id_int(iri: str) -> int:
+    """Return the trailing integer of an IRI for stable numeric sort.
+    Falls back to a large number to keep non-numeric IDs at the end."""
+    tail = iri.rstrip("/").rsplit("/", 1)[-1]
+    if tail.isdigit():
+        return int(tail)
+    return 1_000_000_000
+
+
+def _short_concept(iri: str) -> str:
+    s = str(iri)
+    return s.rsplit("#", 1)[-1].rsplit("/", 1)[-1]
+
+
+def _pretty_concept(name: str) -> str:
+    """Insert spaces before internal capitals: 'DecisionProcedure' -> 'Decision Procedure'."""
+    out: list[str] = []
+    for i, ch in enumerate(name):
+        if i > 0 and ch.isupper() and not name[i - 1].isupper():
+            out.append(" ")
+        out.append(ch)
+    return "".join(out)
+
+
+__all__ = [
+    "COMPILER_ID",
+    "COMPILER_VERSION",
+    "compile_submission",
+    "compile_submission_file",
+]

--- a/src/mgj/compilers/wiki.py
+++ b/src/mgj/compilers/wiki.py
@@ -1,0 +1,407 @@
+"""
+mgj.compilers.wiki
+------------------
+Auto-generate cross-linked wiki pages from the full Metagov Journal graph.
+
+Pages produced (one Markdown file each):
+    Home.md                  Index of all institutions and people
+    Institution-{slug}.md    Per-institution view (rendered via the catechism compiler)
+    Person-{slug}.md         Person dossier with backlinks
+    Organization-{slug}.md   Organization dossier with backlinks
+
+Determinism: queries are ORDER BYed and post-sorted; output is byte-stable
+for a fixed graph state across runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rdflib import Graph
+
+from mgj import graph as graph_mod
+from mgj.compilers.catechism import compile_submission
+from mgj.graph import load_ontology, sparql_select
+from mgj.namespaces import MGJ
+
+WIKI_COMPILER_VERSION = "0.1.0"
+WIKI_COMPILER_ID = "mgj.compilers.wiki"
+
+
+# ---------------------------------------------------------------------------
+# Graph loading — full repo
+# ---------------------------------------------------------------------------
+
+
+def load_full_graph() -> Graph:
+    """Merge ontology + every shared/*.ttl + every submissions/*/instance.ttl.
+
+    Reads ``mgj.graph.SHARED_DIR`` and ``mgj.graph.SUBMISSIONS_DIR`` via
+    the module so test monkeypatching of those attributes is observed.
+    """
+    g = load_ontology()
+    if graph_mod.SHARED_DIR.is_dir():
+        for ttl in sorted(graph_mod.SHARED_DIR.glob("*.ttl")):
+            g.parse(str(ttl), format="turtle")
+    if graph_mod.SUBMISSIONS_DIR.is_dir():
+        for instance in sorted(graph_mod.SUBMISSIONS_DIR.glob("*/instance.ttl")):
+            g.parse(str(instance), format="turtle")
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry: write all pages into ``output_dir``
+# ---------------------------------------------------------------------------
+
+
+def compile_wiki(output_dir: str | Path) -> list[Path]:
+    """Generate the full wiki tree. Returns the list of files written."""
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    g = load_full_graph()
+
+    written: list[Path] = []
+
+    # Home
+    home = out / "Home.md"
+    home.write_text(_render_home(g))
+    written.append(home)
+
+    # Institution pages
+    for inst in _institution_index(g):
+        page = out / f"Institution-{_slug_from_iri(inst['inst'])}.md"
+        page.write_text(_render_institution_page(g, inst))
+        written.append(page)
+
+    # Person pages
+    for person in _person_index(g):
+        page = out / f"Person-{_slug_from_iri(person['p'])}.md"
+        page.write_text(_render_person_page(g, person))
+        written.append(page)
+
+    # Organization pages
+    for org in _org_index(g):
+        page = out / f"Organization-{_slug_from_iri(org['o'])}.md"
+        page.write_text(_render_org_page(g, org))
+        written.append(page)
+
+    return sorted(written)
+
+
+# ---------------------------------------------------------------------------
+# Indexes
+# ---------------------------------------------------------------------------
+
+
+def _institution_index(g: Graph) -> list[dict[str, str]]:
+    return sparql_select(
+        g,
+        """
+        SELECT ?inst ?name WHERE {
+            ?inst a mgj:Institution ; mgj:institutionName ?name .
+        } ORDER BY ?name
+        """,
+    )
+
+
+def _person_index(g: Graph) -> list[dict[str, str]]:
+    return sparql_select(
+        g,
+        """
+        SELECT ?p ?name WHERE {
+            ?p a foaf:Person ; foaf:name ?name .
+        } ORDER BY ?name
+        """,
+    )
+
+
+def _org_index(g: Graph) -> list[dict[str, str]]:
+    return sparql_select(
+        g,
+        """
+        SELECT ?o ?name WHERE {
+            ?o a foaf:Organization ; foaf:name ?name .
+        } ORDER BY ?name
+        """,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Page renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_home(g: Graph) -> str:
+    lines = ["# Metagov Journal", ""]
+    lines.append(f"<!-- compiler: {WIKI_COMPILER_ID} v{WIKI_COMPILER_VERSION} -->")
+    lines.append("")
+
+    institutions = _institution_index(g)
+    lines.append("## Institutions")
+    lines.append("")
+    if institutions:
+        for inst in institutions:
+            slug = _slug_from_iri(inst["inst"])
+            lines.append(f"- [{inst['name']}](Institution-{slug})")
+    else:
+        lines.append("*(none yet)*")
+    lines.append("")
+
+    people = _person_index(g)
+    lines.append("## People")
+    lines.append("")
+    if people:
+        for p in people:
+            slug = _slug_from_iri(p["p"])
+            lines.append(f"- [{p['name']}](Person-{slug})")
+    else:
+        lines.append("*(none yet)*")
+    lines.append("")
+
+    orgs = _org_index(g)
+    lines.append("## Organizations")
+    lines.append("")
+    if orgs:
+        for o in orgs:
+            slug = _slug_from_iri(o["o"])
+            lines.append(f"- [{o['name']}](Organization-{slug})")
+    else:
+        lines.append("*(none yet)*")
+    lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_institution_page(g: Graph, inst: dict[str, str]) -> str:
+    """Render a per-institution page: same content as compiled.md, plus a
+    backlinks section listing related people and orgs."""
+    submissions = sparql_select(
+        g,
+        f"""
+        SELECT ?s ?version ?date WHERE {{
+            ?s a mgj:Submission ;
+               mgj:documents <{inst['inst']}> ;
+               mgj:submissionVersion ?version ;
+               mgj:submissionDate ?date .
+        }} ORDER BY DESC(?date) ?s
+        """,
+    )
+    if not submissions:
+        return f"# {inst['name']}\n\n*No submissions yet.*\n"
+
+    # Use the latest submission as the canonical view for now.
+    latest = submissions[0]["s"]
+    sub_graph = _subgraph_for_submission(g, latest)
+    body = compile_submission(sub_graph)
+
+    if len(submissions) > 1:
+        history = ["", "## Submission history", ""]
+        for s in submissions:
+            history.append(f"- v{s['version']} — {s['date']}")
+        body += "\n".join(history) + "\n"
+
+    return body
+
+
+def _render_person_page(g: Graph, person: dict[str, str]) -> str:
+    p = person["p"]
+    lines = [f"# {person['name']}", ""]
+    lines.append(f"<!-- compiler: {WIKI_COMPILER_ID} v{WIKI_COMPILER_VERSION} -->")
+    lines.append("")
+    lines.append(f"`{p}`")
+    lines.append("")
+
+    # Authorship
+    authored = sparql_select(
+        g,
+        f"""
+        SELECT ?inst ?instName WHERE {{
+            ?s a mgj:Submission ; mgj:authoredBy <{p}> ;
+               mgj:documents ?inst .
+            ?inst mgj:institutionName ?instName .
+        }} ORDER BY ?instName
+        """,
+    )
+    if authored:
+        lines.append("## Authored submissions")
+        lines.append("")
+        for r in authored:
+            slug = _slug_from_iri(r["inst"])
+            lines.append(f"- [{r['instName']}](Institution-{slug})")
+        lines.append("")
+
+    # Stakeholdings
+    stakeholdings = sparql_select(
+        g,
+        f"""
+        SELECT ?role ?inst ?instName WHERE {{
+            ?stakeholder a mgj:Stakeholder ;
+                         mgj:stakeholderAgent <{p}> ;
+                         mgj:roleLabel ?role .
+            ?s a mgj:Submission ; mgj:hasStakeholder ?stakeholder ;
+               mgj:documents ?inst .
+            ?inst mgj:institutionName ?instName .
+        }} ORDER BY ?instName ?role
+        """,
+    )
+    if stakeholdings:
+        lines.append("## Stakeholder roles")
+        lines.append("")
+        for r in stakeholdings:
+            slug = _slug_from_iri(r["inst"])
+            lines.append(
+                f"- **{r['role']}** in [{r['instName']}](Institution-{slug})"
+            )
+        lines.append("")
+
+    # Origin participation
+    origins = sparql_select(
+        g,
+        f"""
+        SELECT ?label ?date ?inst ?instName WHERE {{
+            ?ev a mgj:OriginEvent ;
+                mgj:originParticipant <{p}> ;
+                mgj:originLabel ?label .
+            ?s a mgj:Submission ; mgj:hasOriginEvent ?ev ; mgj:documents ?inst .
+            ?inst mgj:institutionName ?instName .
+            OPTIONAL {{ ?ev mgj:originDate ?date }}
+        }} ORDER BY ?date ?instName
+        """,
+    )
+    if origins:
+        lines.append("## Origin events")
+        lines.append("")
+        for r in origins:
+            slug = _slug_from_iri(r["inst"])
+            d = f" ({r['date']})" if r["date"] else ""
+            lines.append(
+                f"- **{r['label']}**{d} — [{r['instName']}](Institution-{slug})"
+            )
+        lines.append("")
+
+    if not (authored or stakeholdings or origins):
+        lines.append("*No recorded participation yet.*")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_org_page(g: Graph, org: dict[str, str]) -> str:
+    o = org["o"]
+    lines = [f"# {org['name']}", ""]
+    lines.append(f"<!-- compiler: {WIKI_COMPILER_ID} v{WIKI_COMPILER_VERSION} -->")
+    lines.append("")
+    lines.append(f"`{o}`")
+    lines.append("")
+
+    # Hosts (legal context)
+    hosts = sparql_select(
+        g,
+        f"""
+        SELECT ?relationship ?inst ?instName WHERE {{
+            ?lc a mgj:LegalContext ;
+                mgj:hostOrganization <{o}> ;
+                mgj:legalRelationship ?relationship .
+            ?s a mgj:Submission ; mgj:operatesUnder ?lc ; mgj:documents ?inst .
+            ?inst mgj:institutionName ?instName .
+        }} ORDER BY ?instName
+        """,
+    )
+    if hosts:
+        lines.append("## Hosts")
+        lines.append("")
+        for r in hosts:
+            slug = _slug_from_iri(r["inst"])
+            rel = str(r["relationship"]).rsplit("#", 1)[-1]
+            lines.append(
+                f"- {_pretty_concept(rel)} of [{r['instName']}](Institution-{slug})"
+            )
+        lines.append("")
+
+    # Stakeholdings
+    stakeholdings = sparql_select(
+        g,
+        f"""
+        SELECT ?role ?inst ?instName WHERE {{
+            ?stakeholder a mgj:Stakeholder ;
+                         mgj:stakeholderAgent <{o}> ;
+                         mgj:roleLabel ?role .
+            ?s a mgj:Submission ; mgj:hasStakeholder ?stakeholder ;
+               mgj:documents ?inst .
+            ?inst mgj:institutionName ?instName .
+        }} ORDER BY ?instName ?role
+        """,
+    )
+    if stakeholdings:
+        lines.append("## Stakeholder roles")
+        lines.append("")
+        for r in stakeholdings:
+            slug = _slug_from_iri(r["inst"])
+            lines.append(
+                f"- **{r['role']}** in [{r['instName']}](Institution-{slug})"
+            )
+        lines.append("")
+
+    if not (hosts or stakeholdings):
+        lines.append("*No recorded participation yet.*")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _slug_from_iri(iri: str) -> str:
+    return str(iri).rstrip("/").rsplit("/", 1)[-1]
+
+
+def _pretty_concept(name: str) -> str:
+    out: list[str] = []
+    for i, ch in enumerate(name):
+        if i > 0 and ch.isupper() and not name[i - 1].isupper():
+            out.append(" ")
+        out.append(ch)
+    return "".join(out)
+
+
+def _subgraph_for_submission(g: Graph, sub_iri: str) -> Graph:
+    """Build a fresh graph containing only the triples needed for this submission's
+    catechism compilation: the submission, its institution, and all entities
+    transitively reachable from the submission, plus the foaf agents
+    referenced. This keeps the catechism compiler's _single_submission_iri
+    invariant (exactly one mgj:Submission in the graph)."""
+    from rdflib import URIRef
+
+    sub_uri = URIRef(sub_iri)
+    sg = Graph()
+    visited: set[str] = set()
+    frontier: list[str] = [sub_iri]
+
+    while frontier:
+        node = frontier.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        node_uri = URIRef(node)
+        for p, o in g.predicate_objects(node_uri):
+            sg.add((node_uri, p, o))
+            if isinstance(o, URIRef) and str(o) not in visited:
+                # Don't traverse into other Submission nodes; we want a
+                # single-submission graph for the compiler.
+                if (o, MGJ.documents, None) in g:
+                    continue
+                frontier.append(str(o))
+
+    # Bring in the institution + its name (already covered if reached via documents)
+    return sg
+
+
+__all__ = [
+    "WIKI_COMPILER_ID",
+    "WIKI_COMPILER_VERSION",
+    "load_full_graph",
+    "compile_wiki",
+]

--- a/src/mgj/graph.py
+++ b/src/mgj/graph.py
@@ -1,0 +1,113 @@
+"""
+mgj.graph
+---------
+RDFLib graph loading helpers.
+
+Responsibilities:
+- Resolve repo-relative paths to ontology, shapes, and shared registries.
+- Load instance Turtle files, optionally merging shared registries and the
+  ontology.
+- Provide a SPARQL convenience wrapper with standard prefixes.
+
+Path resolution is rooted at the repository, not the current working
+directory: helpers walk up from this file's location to find the project
+root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rdflib import Graph
+from rdflib.plugins.sparql.processor import SPARQLResult
+
+from mgj.namespaces import SPARQL_PREFIXES
+
+_HERE = Path(__file__).parent.resolve()
+_PROJECT_ROOT = _HERE.parent.parent  # src/mgj -> src -> repo root
+
+ONTOLOGY_PATH = _PROJECT_ROOT / "ontology" / "mgj.ttl"
+SHAPES_DIR = _PROJECT_ROOT / "ontology" / "shapes"
+SYSTEM_SHAPES_PATH = SHAPES_DIR / "system.ttl"
+PER_QUESTION_SHAPES_DIR = SHAPES_DIR / "per-question"
+SHARED_DIR = _PROJECT_ROOT / "shared"
+SUBMISSIONS_DIR = _PROJECT_ROOT / "submissions"
+
+
+def project_root() -> Path:
+    return _PROJECT_ROOT
+
+
+def submission_dir(slug: str) -> Path:
+    return SUBMISSIONS_DIR / slug
+
+
+def submission_instance_path(slug: str) -> Path:
+    return submission_dir(slug) / "instance.ttl"
+
+
+def per_question_shapes_path(question: int) -> Path:
+    """Return the path to a per-question shapes file (q1..q9)."""
+    if not 1 <= question <= 9:
+        raise ValueError(f"question must be in 1..9, got {question}")
+    matches = sorted(PER_QUESTION_SHAPES_DIR.glob(f"q{question}-*.ttl"))
+    if not matches:
+        raise FileNotFoundError(
+            f"no shapes file found for question {question} in {PER_QUESTION_SHAPES_DIR}"
+        )
+    if len(matches) > 1:
+        raise RuntimeError(
+            f"multiple shapes files match q{question}-*.ttl: {matches}"
+        )
+    return matches[0]
+
+
+def load_ontology() -> Graph:
+    g = Graph()
+    g.parse(str(ONTOLOGY_PATH), format="turtle")
+    return g
+
+
+def load_system_shapes() -> Graph:
+    g = Graph()
+    g.parse(str(SYSTEM_SHAPES_PATH), format="turtle")
+    return g
+
+
+def load_per_question_shapes(question: int) -> Graph:
+    g = Graph()
+    g.parse(str(per_question_shapes_path(question)), format="turtle")
+    return g
+
+
+def load_shared() -> Graph:
+    """Load every .ttl file under shared/ into one graph."""
+    g = Graph()
+    if SHARED_DIR.is_dir():
+        for ttl in sorted(SHARED_DIR.glob("*.ttl")):
+            g.parse(str(ttl), format="turtle")
+    return g
+
+
+def load_instance(path: str | Path, *, with_shared: bool = True) -> Graph:
+    """Load a submission instance.ttl, optionally merged with shared registries."""
+    g = Graph()
+    if with_shared:
+        for ttl in sorted(SHARED_DIR.glob("*.ttl")) if SHARED_DIR.is_dir() else []:
+            g.parse(str(ttl), format="turtle")
+    g.parse(str(path), format="turtle")
+    return g
+
+
+def sparql_select(graph: Graph, query: str) -> list[dict[str, str]]:
+    """Run a SPARQL SELECT, returning rows as dicts of variable→string."""
+    result: SPARQLResult = graph.query(SPARQL_PREFIXES + query)
+    rows: list[dict[str, str]] = []
+    for row in result:
+        rows.append(
+            {
+                str(var): (str(row[var]) if row[var] is not None else "")
+                for var in result.vars
+            }
+        )
+    return rows

--- a/src/mgj/models.py
+++ b/src/mgj/models.py
@@ -1,0 +1,253 @@
+"""
+mgj.models
+----------
+Pydantic v2 models mirroring the mgj ontology (ontology/mgj.ttl).
+
+Conventions
+-----------
+- Each model maps 1-to-1 to an OWL class.
+- Required fields map to SHACL minCount >= 1; optional fields default to None
+  or empty list.
+- Controlled-vocabulary fields use Literal types listing the SKOS concept
+  IRIs from the closed schemes. New role concepts (open scheme) are passed
+  as plain IRI strings.
+- IRIs are plain strings. Models do not depend on rdflib; the conversion to
+  graphs lives in mgj.serialize.
+
+Catechism question mapping
+--------------------------
+Q1  Submission.q1_narrative + Institution.name (link via Submission.documents_iri)
+Q2  Submission.q2_narrative + Submission.stakeholders
+Q3  Submission.q3_narrative + Submission.environmental_factors
+Q4  Submission.q4_narrative + Submission.constitutional_elements
+Q5  Submission.q5_narrative + Submission.field_sites
+Q6  Submission.q6_narrative + .author_iri / .author_role / .author_disclosure
+Q7  Submission.q7_narrative + Submission.origin_events
+Q8  Submission.q8_narrative + Submission.evolution_mechanisms
+Q9  Submission.q9_narrative + Submission.references
+Cross-question structural: Submission.legal_context (operatesUnder)
+"""
+
+from __future__ import annotations
+
+from datetime import date as DateT
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+
+NonEmptyStr = Annotated[str, Field(min_length=1)]
+"""Mirrors sh:minLength 1."""
+
+IRI = str
+"""An IRI as a plain string. Not validated as a URL — may be any valid IRI."""
+
+
+# ---------------------------------------------------------------------------
+# Controlled-vocabulary Literals (closed SKOS schemes)
+# ---------------------------------------------------------------------------
+
+LessigModalityT = Literal["Law", "Norms", "Markets", "Architecture"]
+
+ConstitutionalElementTypeT = Literal[
+    "Bylaw",
+    "Norm",
+    "DecisionProcedure",
+    "DisputeResolution",
+    "AmendmentProcess",
+]
+
+LegalRelationshipT = Literal[
+    "FiscalSponsor",
+    "LegalIncorporation",
+    "ParentOrganization",
+    "Incubator",
+    "Network",
+]
+
+
+# ---------------------------------------------------------------------------
+# Shared agents (live in shared/people.ttl, shared/organizations.ttl)
+# ---------------------------------------------------------------------------
+
+
+class Person(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    iri: IRI
+    name: NonEmptyStr
+    homepage: HttpUrl | None = None
+
+
+class Organization(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    iri: IRI
+    name: NonEmptyStr
+    homepage: HttpUrl | None = None
+
+
+class UnresolvedAgent(BaseModel):
+    """Parser placeholder for an agent reference too vague to type. Must be
+    resolved (replaced with a Person or Organization) before system validation."""
+
+    model_config = ConfigDict(frozen=True)
+    iri: IRI
+    label: NonEmptyStr
+
+
+# ---------------------------------------------------------------------------
+# Persistent institution
+# ---------------------------------------------------------------------------
+
+
+class Institution(BaseModel):
+    iri: IRI
+    name: NonEmptyStr
+    description: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Per-question typed entities
+# ---------------------------------------------------------------------------
+
+
+class Stakeholder(BaseModel):
+    """Q2 — n-ary connector between agent, role, and submission."""
+
+    iri: IRI
+    agent_iri: IRI
+    """foaf:Person, foaf:Organization, or mgj:UnresolvedAgent IRI."""
+    role_label: NonEmptyStr
+    role_iri: IRI | None = None
+    """SKOS concept in mgj:RoleType. Required at system level; optional inner-loop."""
+    responsibilities: str | None = None
+
+
+class FieldSite(BaseModel):
+    """Q5."""
+
+    iri: IRI
+    label: NonEmptyStr
+    url: HttpUrl | None = None
+    description: str | None = None
+
+
+class EnvironmentalFactor(BaseModel):
+    """Q3 — Lessig-typed."""
+
+    iri: IRI
+    modality: LessigModalityT
+    description: NonEmptyStr
+
+
+class ConstitutionalElement(BaseModel):
+    """Q4."""
+
+    iri: IRI
+    label: NonEmptyStr
+    description: NonEmptyStr
+    element_type: ConstitutionalElementTypeT
+    source_url: HttpUrl | None = None
+
+
+class OriginEvent(BaseModel):
+    """Q7 — subClassOf prov:Activity."""
+
+    iri: IRI
+    label: NonEmptyStr
+    description: NonEmptyStr
+    date: DateT | None = None
+    participant_iris: list[IRI] = Field(default_factory=list)
+
+
+class EvolutionMechanism(BaseModel):
+    """Q8."""
+
+    iri: IRI
+    label: NonEmptyStr
+    description: NonEmptyStr
+
+
+class Reference(BaseModel):
+    """Q9 — bibliographic entry, dcterms-driven."""
+
+    iri: IRI
+    title: NonEmptyStr
+    identifier: NonEmptyStr
+    """DOI, URL, or other canonical identifier."""
+    creators: list[str] = Field(default_factory=list)
+    date: str | None = None
+    """Free-form date (year, ISO date, or 'forthcoming') — not strictly typed."""
+
+
+class LegalContext(BaseModel):
+    """Cross-question — host org + relationship type."""
+
+    iri: IRI
+    host_organization_iri: IRI
+    legal_relationship: LegalRelationshipT
+    description: NonEmptyStr
+    funding_reference: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Top-level submission
+# ---------------------------------------------------------------------------
+
+
+class Submission(BaseModel):
+    iri: IRI
+    institution_iri: IRI
+    submission_date: DateT
+    submission_version: NonEmptyStr
+
+    # Q6 author disclosure
+    author_iri: IRI | None = None
+    author_role: str | None = None
+    author_disclosure: str | None = None
+
+    # Per-question narratives
+    q1_narrative: str | None = None
+    q2_narrative: str | None = None
+    q3_narrative: str | None = None
+    q4_narrative: str | None = None
+    q5_narrative: str | None = None
+    q6_narrative: str | None = None
+    q7_narrative: str | None = None
+    q8_narrative: str | None = None
+    q9_narrative: str | None = None
+
+    # Per-question typed entities
+    stakeholders: list[Stakeholder] = Field(default_factory=list)
+    environmental_factors: list[EnvironmentalFactor] = Field(default_factory=list)
+    constitutional_elements: list[ConstitutionalElement] = Field(default_factory=list)
+    field_sites: list[FieldSite] = Field(default_factory=list)
+    origin_events: list[OriginEvent] = Field(default_factory=list)
+    evolution_mechanisms: list[EvolutionMechanism] = Field(default_factory=list)
+    references: list[Reference] = Field(default_factory=list)
+
+    # Cross-question structural
+    legal_context: LegalContext | None = None
+
+    # Parser carryover (entities that surfaced but weren't resolved yet)
+    unresolved_agents: list[UnresolvedAgent] = Field(default_factory=list)
+
+
+__all__ = [
+    "NonEmptyStr",
+    "IRI",
+    "LessigModalityT",
+    "ConstitutionalElementTypeT",
+    "LegalRelationshipT",
+    "Person",
+    "Organization",
+    "UnresolvedAgent",
+    "Institution",
+    "Stakeholder",
+    "FieldSite",
+    "EnvironmentalFactor",
+    "ConstitutionalElement",
+    "OriginEvent",
+    "EvolutionMechanism",
+    "Reference",
+    "LegalContext",
+    "Submission",
+]

--- a/src/mgj/namespaces.py
+++ b/src/mgj/namespaces.py
@@ -1,0 +1,100 @@
+"""
+mgj.namespaces
+--------------
+Namespace bindings and IRI minting helpers for the Metagov Journal ontology.
+
+A single source of truth for the IRI conventions:
+
+    https://journal.metagov.org/ns/mgj#                ontology terms
+    https://journal.metagov.org/institutions/{slug}    persistent institution IRIs
+    https://journal.metagov.org/submissions/{slug}/    per-submission entity IRIs
+    https://journal.metagov.org/people/{slug}          shared people registry
+    https://journal.metagov.org/orgs/{slug}            shared organizations registry
+    https://journal.metagov.org/roles/{slug}           SKOS role concepts
+"""
+
+from __future__ import annotations
+
+from rdflib import Namespace
+from rdflib.namespace import DCTERMS, FOAF, OWL, RDF, RDFS, SKOS, XSD
+
+# Core mgj namespace (matches ontology/mgj.ttl).
+MGJ = Namespace("https://journal.metagov.org/ns/mgj#")
+
+# PROV-O.
+PROV = Namespace("http://www.w3.org/ns/prov#")
+
+# IRI roots for minted instance entities.
+INSTITUTIONS_BASE = "https://journal.metagov.org/institutions/"
+SUBMISSIONS_BASE = "https://journal.metagov.org/submissions/"
+PEOPLE_BASE = "https://journal.metagov.org/people/"
+ORGS_BASE = "https://journal.metagov.org/orgs/"
+ROLES_BASE = "https://journal.metagov.org/roles/"
+
+
+def institution_iri(slug: str) -> str:
+    return f"{INSTITUTIONS_BASE}{slug}"
+
+
+def submission_iri(slug: str, version: str) -> str:
+    return f"{SUBMISSIONS_BASE}{slug}/v{version}"
+
+
+def person_iri(slug: str) -> str:
+    return f"{PEOPLE_BASE}{slug}"
+
+
+def organization_iri(slug: str) -> str:
+    return f"{ORGS_BASE}{slug}"
+
+
+def role_iri(slug: str) -> str:
+    return f"{ROLES_BASE}{slug}"
+
+
+def submission_entity_iri(slug: str, version: str, kind: str, local_id: str) -> str:
+    """Mint an IRI for a per-submission entity (Stakeholder, FieldSite, etc.).
+
+    Example:
+        submission_entity_iri("metagov-journal", "1.0.0", "stakeholder", "1")
+        → "https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/1"
+    """
+    return f"{SUBMISSIONS_BASE}{slug}/v{version}/{kind}/{local_id}"
+
+
+# Standard prefix block for SPARQL queries.
+SPARQL_PREFIXES = """
+PREFIX mgj:     <https://journal.metagov.org/ns/mgj#>
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+PREFIX prov:    <http://www.w3.org/ns/prov#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+"""
+
+
+__all__ = [
+    "MGJ",
+    "PROV",
+    "FOAF",
+    "DCTERMS",
+    "SKOS",
+    "OWL",
+    "RDF",
+    "RDFS",
+    "XSD",
+    "INSTITUTIONS_BASE",
+    "SUBMISSIONS_BASE",
+    "PEOPLE_BASE",
+    "ORGS_BASE",
+    "ROLES_BASE",
+    "institution_iri",
+    "submission_iri",
+    "person_iri",
+    "organization_iri",
+    "role_iri",
+    "submission_entity_iri",
+    "SPARQL_PREFIXES",
+]

--- a/src/mgj/parser/backends.py
+++ b/src/mgj/parser/backends.py
@@ -1,0 +1,183 @@
+"""
+mgj.parser.backends
+-------------------
+Provider-agnostic LLM extraction interface.
+
+The parser depends on the ``LLMBackend`` Protocol; concrete backends
+plug in via dependency injection. Today there's a Claude backend; a
+GPT/Gemini/local backend can be added by implementing the same
+interface without touching the rest of the parser.
+
+The Protocol contract:
+    extract(system_prompt, user_prompt, json_schema, max_tokens=...)
+        → ExtractionResult{parsed, model_id, prompt_hash, input_hash, timestamp}
+
+Backends should:
+- Use structured output / tool use to produce JSON conforming to
+  ``json_schema``.
+- Cache stable parts of the prompt where supported (Claude: ephemeral
+  prompt cache).
+- Return a deterministic ``model_id`` string.
+
+The backend MUST NOT do its own validation against ``json_schema`` —
+the parser layer does that. The backend's job is "talk to the model
+and return what it said as a dict."
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Any, Callable, Protocol
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    """Structured response from an ``LLMBackend.extract`` call.
+
+    ``parsed`` is the model's JSON output as a dict. ``model_id`` and
+    the hashes give us provenance and cache-key material.
+    """
+
+    parsed: dict[str, Any]
+    model_id: str
+    prompt_hash: str
+    input_hash: str
+    timestamp: str
+
+
+class LLMBackend(Protocol):
+    """Provider-agnostic structured-extraction interface."""
+
+    def extract(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        json_schema: dict[str, Any],
+        max_tokens: int = 4096,
+    ) -> ExtractionResult: ...
+
+
+# ---------------------------------------------------------------------------
+# Claude backend (default)
+# ---------------------------------------------------------------------------
+
+
+class ClaudeBackend:
+    """Anthropic Claude implementation.
+
+    Uses tool-use to produce JSON output conforming to the schema. The
+    ``system_prompt`` is sent with ``cache_control`` so multiple
+    extractions over the same per-question prompt template hit the
+    Anthropic prompt cache.
+    """
+
+    DEFAULT_MODEL = "claude-sonnet-4-6"
+
+    def __init__(self, model: str | None = None, api_key: str | None = None):
+        # Imported lazily so the rest of the package works without anthropic installed.
+        from anthropic import Anthropic
+
+        self._model = model or self.DEFAULT_MODEL
+        self._client = Anthropic(api_key=api_key) if api_key else Anthropic()
+
+    def extract(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        json_schema: dict[str, Any],
+        max_tokens: int = 4096,
+    ) -> ExtractionResult:
+        tool = {
+            "name": "record_extraction",
+            "description": "Record the extracted entities for this catechism question.",
+            "input_schema": json_schema,
+        }
+        msg = self._client.messages.create(
+            model=self._model,
+            max_tokens=max_tokens,
+            system=[
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[{"role": "user", "content": user_prompt}],
+            tools=[tool],
+            tool_choice={"type": "tool", "name": "record_extraction"},
+        )
+        for block in msg.content:
+            if getattr(block, "type", None) == "tool_use" and block.name == "record_extraction":
+                return ExtractionResult(
+                    parsed=block.input,
+                    model_id=self._model,
+                    prompt_hash=_sha(system_prompt),
+                    input_hash=_sha(user_prompt),
+                    timestamp=_now_iso(),
+                )
+        raise RuntimeError(
+            f"Claude did not return a record_extraction tool_use block "
+            f"(stop_reason={msg.stop_reason})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mock backend for tests
+# ---------------------------------------------------------------------------
+
+
+class MockLLMBackend:
+    """Test double that returns whatever a callable produces.
+
+    Use in unit tests to drive extraction deterministically without an
+    API call. The callable receives ``(system_prompt, user_prompt)`` and
+    returns the parsed dict that would have come from a real model.
+    """
+
+    def __init__(
+        self,
+        responder: Callable[[str, str], dict[str, Any]],
+        *,
+        model_id: str = "mock-llm-1",
+    ):
+        self._responder = responder
+        self._model_id = model_id
+        self.calls: list[tuple[str, str]] = []
+
+    def extract(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        json_schema: dict[str, Any],
+        max_tokens: int = 4096,
+    ) -> ExtractionResult:
+        self.calls.append((system_prompt, user_prompt))
+        parsed = self._responder(system_prompt, user_prompt)
+        return ExtractionResult(
+            parsed=parsed,
+            model_id=self._model_id,
+            prompt_hash=_sha(system_prompt),
+            input_hash=_sha(user_prompt),
+            timestamp="2026-01-01T00:00:00Z",
+        )
+
+
+def _sha(s: str) -> str:
+    return sha256(s.encode("utf-8")).hexdigest()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "ExtractionResult",
+    "LLMBackend",
+    "ClaudeBackend",
+    "MockLLMBackend",
+]

--- a/src/mgj/parser/cache.py
+++ b/src/mgj/parser/cache.py
@@ -1,0 +1,68 @@
+"""
+mgj.parser.cache
+----------------
+Local extraction-result cache.
+
+Cache key: SHA-256 over (model_id, prompt_hash, input_hash). On cache
+hit we skip the API call entirely and replay the prior parsed output.
+
+Cache files live under ``submissions/<slug>/.cache/extractions/<key>.json``.
+Each file is a JSON serialization of the ``ExtractionResult``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from hashlib import sha256
+from pathlib import Path
+
+from mgj.parser.backends import ExtractionResult
+
+
+def cache_dir(submission_dir: Path) -> Path:
+    return submission_dir / ".cache" / "extractions"
+
+
+def cache_key(*, model_id: str, prompt_hash: str, input_hash: str) -> str:
+    h = sha256()
+    h.update(model_id.encode("utf-8"))
+    h.update(b"|")
+    h.update(prompt_hash.encode("utf-8"))
+    h.update(b"|")
+    h.update(input_hash.encode("utf-8"))
+    return h.hexdigest()
+
+
+def cache_path(submission_dir: Path, *, model_id: str, prompt_hash: str, input_hash: str) -> Path:
+    return cache_dir(submission_dir) / f"{cache_key(model_id=model_id, prompt_hash=prompt_hash, input_hash=input_hash)}.json"
+
+
+def load_cached(
+    submission_dir: Path,
+    *,
+    model_id: str,
+    prompt_hash: str,
+    input_hash: str,
+) -> ExtractionResult | None:
+    p = cache_path(
+        submission_dir,
+        model_id=model_id,
+        prompt_hash=prompt_hash,
+        input_hash=input_hash,
+    )
+    if not p.exists():
+        return None
+    data = json.loads(p.read_text())
+    return ExtractionResult(**data)
+
+
+def save_cached(submission_dir: Path, result: ExtractionResult) -> None:
+    cache_dir(submission_dir).mkdir(parents=True, exist_ok=True)
+    p = cache_path(
+        submission_dir,
+        model_id=result.model_id,
+        prompt_hash=result.prompt_hash,
+        input_hash=result.input_hash,
+    )
+    p.write_text(json.dumps(asdict(result), indent=2, sort_keys=True) + "\n")

--- a/src/mgj/parser/extract.py
+++ b/src/mgj/parser/extract.py
@@ -1,0 +1,471 @@
+"""
+mgj.parser.extract
+------------------
+Orchestration: input.md → typed RDF triples.
+
+Per-question pipeline:
+    1. Slice input.md to the Qi section.
+    2. Set the q{i}Narrative literal on the Submission (always done).
+    3. If Qi has a parser schema, call the LLMBackend for structured output.
+    4. Validate the output via Pydantic.
+    5. Convert each parsed entity to RDF triples (minted IRIs, provenance
+       stamps, links from Submission).
+    6. Reconcile against the existing graph (see ``reconcile.py``):
+       parser-output entities for unaffirmed Qi are replaced; affirmed
+       entities are sticky.
+    7. Save the canonicalized graph; record an Extraction provenance
+       node with model id, prompt hash, input SHA, timestamp.
+
+Caching: per-question (input_section_sha, prompt_hash, model_id) keyed
+file cache under ``submissions/<slug>/.cache/extractions/``. On cache
+hit we skip the backend call entirely.
+
+Affirmation guard: if Qi is already affirmed in extraction-trace.json,
+``extract`` refuses to re-run for that Qi unless ``force=True``. The
+expected workflow is `mgj unaffirm -q N` first.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import RDF, XSD
+
+from mgj.canonicalize import canonicalize_turtle
+from mgj.commands._common import (
+    ExtractionTrace,
+    load_trace,
+    save_trace,
+)
+from mgj.graph import submission_dir, submission_instance_path
+from mgj.namespaces import MGJ, submission_entity_iri
+from mgj.parser import cache as cache_mod
+from mgj.parser import reconcile as reconcile_mod
+from mgj.parser.backends import ExtractionResult, LLMBackend
+from mgj.parser.prompts import system_prompt_for_question
+from mgj.parser.schemas import EXTRACTION_SCHEMAS, QUESTIONS_WITH_ENTITIES
+
+# ---------------------------------------------------------------------------
+# Top-level entry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExtractionRunResult:
+    """Summary returned by ``run_extraction``."""
+
+    extracted_questions: list[int]
+    skipped_affirmed: list[int]
+    cache_hits: list[int]
+    cache_misses: list[int]
+
+
+def run_extraction(
+    slug: str,
+    *,
+    backend: LLMBackend,
+    questions: list[int] | None = None,
+    force: bool = False,
+) -> ExtractionRunResult:
+    """Extract typed RDF triples from input.md for the given submission.
+
+    Parameters
+    ----------
+    slug : str
+        Submission slug.
+    backend : LLMBackend
+        Provider-agnostic structured-output backend.
+    questions : list[int] | None
+        If given, only these questions are extracted. Default: all
+        questions that have entity schemas (Q2..Q9).
+    force : bool
+        If True, re-extract even for already-affirmed questions.
+    """
+    sdir = submission_dir(slug)
+    input_md = sdir / "input.md"
+    if not input_md.exists():
+        raise FileNotFoundError(f"no input.md at {input_md}")
+
+    sections = parse_input_sections(input_md.read_text())
+
+    instance_path = submission_instance_path(slug)
+    g = Graph()
+    g.parse(str(instance_path), format="turtle")
+
+    # Find the (single) Submission IRI; it's the canonical attachment point.
+    sub = _single_submission_iri(g)
+    version = _scalar(g, sub, MGJ.submissionVersion)
+
+    trace = load_trace(slug)
+    qs = questions if questions is not None else QUESTIONS_WITH_ENTITIES
+
+    extracted: list[int] = []
+    skipped_affirmed: list[int] = []
+    cache_hits: list[int] = []
+    cache_misses: list[int] = []
+
+    # Always set narratives for whatever sections appear, regardless of
+    # whether we run extraction. Narratives carry the author's prose
+    # and should round-trip to the compiled output.
+    for q in range(1, 10):
+        if q in sections:
+            _set_narrative(g, sub, q, sections[q])
+
+    for q in qs:
+        if q not in sections:
+            continue
+        if not force and trace.affirmed_questions.get(q):
+            skipped_affirmed.append(q)
+            continue
+
+        prose = sections[q]
+        schema_cls = EXTRACTION_SCHEMAS[q]
+        json_schema = schema_cls.model_json_schema()
+        system_prompt = system_prompt_for_question(q)
+        user_prompt = prose
+
+        # Cache lookup first: we don't even need to know model_id without a call,
+        # so we use a stable convention: store the latest call's model_id under
+        # the (prompt_hash, input_hash) bucket. Implementation: try to find any
+        # cached entry whose prompt_hash + input_hash match.
+        cached = _lookup_cache(
+            sdir,
+            prompt=system_prompt,
+            user=user_prompt,
+        )
+        if cached is not None:
+            cache_hits.append(q)
+            result = cached
+        else:
+            cache_misses.append(q)
+            result = backend.extract(
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                json_schema=json_schema,
+            )
+            cache_mod.save_cached(sdir, result)
+
+        parsed = schema_cls.model_validate(result.parsed)
+
+        # Record an mgj:Extraction activity that we'll attach as
+        # provenance to every parser-output entity for this question.
+        extraction_iri = URIRef(
+            submission_entity_iri(slug, version, "extraction", f"q{q}-{result.timestamp.replace(':','').replace('-','')}")
+        )
+        _record_extraction_activity(g, extraction_iri, q, result)
+
+        # Reconcile: drop unaffirmed parser-output entities for this Qi.
+        reconcile_mod.drop_parser_output_for_question(g, sub, q)
+
+        # Convert parsed -> triples + link to Submission.
+        _apply_extracted(g, sub, slug, version, q, parsed, extraction_iri)
+
+        extracted.append(q)
+        # Record the extraction in the trace's extraction log.
+        trace.extractions.append(
+            {
+                "question": q,
+                "model": result.model_id,
+                "prompt_hash": result.prompt_hash,
+                "input_hash": result.input_hash,
+                "extracted_at": result.timestamp,
+                "from_cache": cached is not None,
+            }
+        )
+
+    # Save back: separate shared subjects (the per-submission file
+    # shouldn't redeclare them).
+    from mgj.commands._common import save_submission_graph_separating_shared
+
+    save_submission_graph_separating_shared(g, slug)
+    save_trace(trace)
+
+    return ExtractionRunResult(
+        extracted_questions=extracted,
+        skipped_affirmed=skipped_affirmed,
+        cache_hits=cache_hits,
+        cache_misses=cache_misses,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section slicer
+# ---------------------------------------------------------------------------
+
+_HEADING_RE = re.compile(r"^##\s+(\d+)\.\s+", re.MULTILINE)
+
+
+def parse_input_sections(text: str) -> dict[int, str]:
+    """Split input.md into a {question_number: section_prose} dict.
+
+    Headings are recognized as ``## N. ...`` per the input.md template.
+    The Q1 marker line itself is included in the slice (helpful context
+    for the model). Trailing whitespace is stripped.
+    """
+    matches = list(_HEADING_RE.finditer(text))
+    if not matches:
+        return {}
+    sections: dict[int, str] = {}
+    for i, m in enumerate(matches):
+        q = int(m.group(1))
+        if not 1 <= q <= 9:
+            continue
+        start = m.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        sections[q] = text[start:end].strip()
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# Cache lookup: any entry with matching prompt+input
+# ---------------------------------------------------------------------------
+
+
+def _lookup_cache(submission_dir: Path, *, prompt: str, user: str) -> ExtractionResult | None:
+    """Look for any cached extraction with matching prompt+input hashes,
+    regardless of model id. Returns the most recent match or None."""
+    from hashlib import sha256
+
+    prompt_hash = sha256(prompt.encode("utf-8")).hexdigest()
+    input_hash = sha256(user.encode("utf-8")).hexdigest()
+
+    cdir = cache_mod.cache_dir(submission_dir)
+    if not cdir.exists():
+        return None
+    import json
+
+    candidates: list[ExtractionResult] = []
+    for f in sorted(cdir.glob("*.json")):
+        try:
+            data = json.loads(f.read_text())
+        except json.JSONDecodeError:
+            continue
+        if data.get("prompt_hash") == prompt_hash and data.get("input_hash") == input_hash:
+            candidates.append(ExtractionResult(**data))
+    if not candidates:
+        return None
+    # Return the most recent by timestamp.
+    return max(candidates, key=lambda r: r.timestamp)
+
+
+# ---------------------------------------------------------------------------
+# Apply parsed extractions → RDF triples
+# ---------------------------------------------------------------------------
+
+
+def _apply_extracted(
+    g: Graph,
+    sub: URIRef,
+    slug: str,
+    version: str,
+    q: int,
+    parsed,
+    extraction_iri: URIRef,
+) -> None:
+    """Dispatch per-question to a specialized triple-emission helper."""
+    if q == 2:
+        _emit_stakeholders(g, sub, slug, version, parsed, extraction_iri)
+    elif q == 3:
+        _emit_factors(g, sub, slug, version, parsed, extraction_iri)
+    elif q == 4:
+        _emit_constitutional(g, sub, slug, version, parsed, extraction_iri)
+    elif q == 5:
+        _emit_field_sites(g, sub, slug, version, parsed, extraction_iri)
+    elif q == 6:
+        _emit_q6(g, sub, slug, version, parsed, extraction_iri)
+    elif q == 7:
+        _emit_origin_events(g, sub, slug, version, parsed, extraction_iri)
+    elif q == 8:
+        _emit_evolution(g, sub, slug, version, parsed, extraction_iri)
+    elif q == 9:
+        _emit_references(g, sub, slug, version, parsed, extraction_iri)
+
+
+def _next_id(g: Graph, slug: str, version: str, kind: str, owl_class: str) -> str:
+    """Find next free integer id for kind, accounting for entities currently in graph."""
+    base = submission_entity_iri(slug, version, kind, "")
+    nums: list[int] = []
+    for s in g.subjects(RDF.type, MGJ[owl_class]):
+        iri = str(s)
+        if iri.startswith(base):
+            tail = iri[len(base):]
+            if tail.isdigit():
+                nums.append(int(tail))
+    return str(max(nums, default=0) + 1)
+
+
+def _emit_stakeholders(g, sub, slug, version, parsed, extraction_iri):
+    for s in parsed.stakeholders:
+        sid = _next_id(g, slug, version, "stakeholder", "Stakeholder")
+        node = URIRef(submission_entity_iri(slug, version, "stakeholder", sid))
+        g.add((node, RDF.type, MGJ.Stakeholder))
+
+        # Mint an UnresolvedAgent for the agent_label; author resolves later.
+        ua_id = _next_id(g, slug, version, "unresolved", "UnresolvedAgent")
+        ua = URIRef(submission_entity_iri(slug, version, "unresolved", ua_id))
+        g.add((ua, RDF.type, MGJ.UnresolvedAgent))
+        g.add((ua, MGJ.unresolvedLabel, Literal(s.agent_label)))
+
+        g.add((node, MGJ.stakeholderAgent, ua))
+        g.add((node, MGJ.roleLabel, Literal(s.role_label)))
+        if s.responsibilities:
+            g.add((node, MGJ.stakeholderResponsibilities, Literal(s.responsibilities)))
+        g.add((node, MGJ.extractedBy, extraction_iri))
+        g.add((sub, MGJ.hasStakeholder, node))
+
+
+def _emit_factors(g, sub, slug, version, parsed, extraction_iri):
+    for f in parsed.factors:
+        fid = _next_id(g, slug, version, "factor", "EnvironmentalFactor")
+        node = URIRef(submission_entity_iri(slug, version, "factor", fid))
+        g.add((node, RDF.type, MGJ.EnvironmentalFactor))
+        g.add((node, MGJ.lessigModality, MGJ[f.modality]))
+        g.add((node, MGJ.factorDescription, Literal(f.description)))
+        g.add((node, MGJ.extractedBy, extraction_iri))
+        g.add((sub, MGJ.hasEnvironmentalFactor, node))
+
+
+def _emit_constitutional(g, sub, slug, version, parsed, extraction_iri):
+    for c in parsed.elements:
+        cid = _next_id(g, slug, version, "constitution", "ConstitutionalElement")
+        node = URIRef(submission_entity_iri(slug, version, "constitution", cid))
+        g.add((node, RDF.type, MGJ.ConstitutionalElement))
+        g.add((node, MGJ.elementLabel, Literal(c.label)))
+        g.add((node, MGJ.elementDescription, Literal(c.description)))
+        g.add((node, MGJ.elementType, MGJ[c.element_type]))
+        if c.source_url:
+            g.add((node, MGJ.elementSourceURL, Literal(c.source_url, datatype=XSD.anyURI)))
+        g.add((node, MGJ.extractedBy, extraction_iri))
+        g.add((sub, MGJ.hasConstitutionalElement, node))
+
+
+def _emit_field_sites(g, sub, slug, version, parsed, extraction_iri):
+    for f in parsed.field_sites:
+        fid = _next_id(g, slug, version, "fieldsite", "FieldSite")
+        node = URIRef(submission_entity_iri(slug, version, "fieldsite", fid))
+        g.add((node, RDF.type, MGJ.FieldSite))
+        g.add((node, MGJ.fieldSiteLabel, Literal(f.label)))
+        if f.url:
+            g.add((node, MGJ.fieldSiteURL, Literal(f.url, datatype=XSD.anyURI)))
+        if f.description:
+            g.add((node, MGJ.fieldSiteDescription, Literal(f.description)))
+        g.add((node, MGJ.extractedBy, extraction_iri))
+        g.add((sub, MGJ.hasFieldSite, node))
+
+
+def _emit_q6(g, sub, slug, version, parsed, extraction_iri):
+    """Q6 is a singleton: set authorRole, authorDisclosure on the
+    Submission, and create an UnresolvedAgent for the author_label so
+    the author can resolve to a Person."""
+    if parsed.author_role:
+        g.remove((sub, MGJ.authorRole, None))
+        g.add((sub, MGJ.authorRole, Literal(parsed.author_role)))
+    if parsed.disclosure:
+        g.remove((sub, MGJ.authorDisclosure, None))
+        g.add((sub, MGJ.authorDisclosure, Literal(parsed.disclosure)))
+    if parsed.author_label:
+        ua_id = _next_id(g, slug, version, "unresolved", "UnresolvedAgent")
+        ua = URIRef(submission_entity_iri(slug, version, "unresolved", ua_id))
+        g.add((ua, RDF.type, MGJ.UnresolvedAgent))
+        g.add((ua, MGJ.unresolvedLabel, Literal(parsed.author_label)))
+        g.add((ua, MGJ.extractedBy, extraction_iri))
+        # NOT linked via authoredBy yet — author must resolve and use
+        # `mgj author set` to install the foaf:Person.
+
+
+def _emit_origin_events(g, sub, slug, version, parsed, extraction_iri):
+    for ev in parsed.events:
+        eid = _next_id(g, slug, version, "origin", "OriginEvent")
+        node = URIRef(submission_entity_iri(slug, version, "origin", eid))
+        g.add((node, RDF.type, MGJ.OriginEvent))
+        g.add((node, MGJ.originLabel, Literal(ev.label)))
+        g.add((node, MGJ.originDescription, Literal(ev.description)))
+        if ev.date:
+            g.add((node, MGJ.originDate, Literal(ev.date, datatype=XSD.date)))
+        for label in ev.participant_labels:
+            ua_id = _next_id(g, slug, version, "unresolved", "UnresolvedAgent")
+            ua = URIRef(submission_entity_iri(slug, version, "unresolved", ua_id))
+            g.add((ua, RDF.type, MGJ.UnresolvedAgent))
+            g.add((ua, MGJ.unresolvedLabel, Literal(label)))
+            g.add((node, MGJ.originParticipant, ua))
+        g.add((node, MGJ.extractedBy, extraction_iri))
+        g.add((sub, MGJ.hasOriginEvent, node))
+
+
+def _emit_evolution(g, sub, slug, version, parsed, extraction_iri):
+    for m in parsed.mechanisms:
+        mid = _next_id(g, slug, version, "evolution", "EvolutionMechanism")
+        node = URIRef(submission_entity_iri(slug, version, "evolution", mid))
+        g.add((node, RDF.type, MGJ.EvolutionMechanism))
+        g.add((node, MGJ.mechanismLabel, Literal(m.label)))
+        g.add((node, MGJ.mechanismDescription, Literal(m.description)))
+        g.add((node, MGJ.extractedBy, extraction_iri))
+        g.add((sub, MGJ.hasEvolutionMechanism, node))
+
+
+def _emit_references(g, sub, slug, version, parsed, extraction_iri):
+    from rdflib.namespace import DCTERMS
+
+    for r in parsed.references:
+        rid = _next_id(g, slug, version, "reference", "Reference")
+        node = URIRef(submission_entity_iri(slug, version, "reference", rid))
+        g.add((node, RDF.type, MGJ.Reference))
+        g.add((node, DCTERMS.title, Literal(r.title)))
+        g.add((node, DCTERMS.identifier, Literal(r.identifier)))
+        if r.date:
+            g.add((node, DCTERMS.date, Literal(r.date)))
+        for c in r.creators:
+            g.add((node, DCTERMS.creator, Literal(c)))
+        g.add((node, MGJ.extractedBy, extraction_iri))
+        g.add((sub, MGJ.hasReference, node))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_narrative(g: Graph, sub: URIRef, q: int, section: str) -> None:
+    """Strip the ``## N. ...`` heading line from the section and store
+    the remaining prose as the q{i}Narrative literal."""
+    body_lines = [ln for ln in section.splitlines() if not ln.startswith("## ")]
+    body = "\n".join(body_lines).strip()
+    if not body:
+        return
+    prop = MGJ[f"q{q}Narrative"]
+    g.remove((sub, prop, None))
+    g.add((sub, prop, Literal(body)))
+
+
+def _record_extraction_activity(
+    g: Graph, extraction_iri: URIRef, q: int, result: ExtractionResult
+) -> None:
+    g.add((extraction_iri, RDF.type, MGJ.Extraction))
+    g.add((extraction_iri, MGJ.extractionModel, Literal(result.model_id)))
+    g.add((extraction_iri, MGJ.promptHash, Literal(result.prompt_hash)))
+    g.add((extraction_iri, MGJ.inputHash, Literal(result.input_hash)))
+    g.add((extraction_iri, MGJ.extractedAt, Literal(result.timestamp, datatype=XSD.dateTime)))
+
+
+def _single_submission_iri(g: Graph) -> URIRef:
+    subjects = list(g.subjects(RDF.type, MGJ.Submission))
+    if len(subjects) != 1:
+        raise ValueError(f"expected one mgj:Submission; found {len(subjects)}")
+    return subjects[0]
+
+
+def _scalar(g: Graph, subject: URIRef, prop: URIRef) -> str:
+    val = next(iter(g.objects(subject, prop)), None)
+    if val is None:
+        raise ValueError(f"missing {prop} on {subject}")
+    return str(val)
+
+
+__all__ = [
+    "ExtractionRunResult",
+    "run_extraction",
+    "parse_input_sections",
+]

--- a/src/mgj/parser/prompts.py
+++ b/src/mgj/parser/prompts.py
@@ -1,0 +1,185 @@
+"""
+mgj.parser.prompts
+------------------
+Per-question system prompts for the LLM extractor.
+
+Each prompt declares:
+- The catechism question and its purpose.
+- The target entity types and required fields.
+- Disambiguation rules (when to merge, when to split, when to flag as
+  unresolved vs. omit).
+
+Prompts are kept in Python rather than separate Markdown files so they
+ship with the package and can't drift out of sync with the schemas in
+``mgj.parser.schemas``.
+
+The prompt strings are stable inputs to the prompt cache (Claude
+ephemeral cache), so resist editing them casually — every change
+invalidates the cache for previously-extracted submissions.
+"""
+
+from __future__ import annotations
+
+SHARED_PREAMBLE = """\
+You are extracting structured records from one section of a Metagov
+Journal catechism submission. The author has written prose answering
+one of nine catechism questions about a "living institution"; your job
+is to identify the typed entities the prose describes and emit them as
+JSON via the `record_extraction` tool.
+
+General rules:
+- Stay close to the source. Do not infer entities the prose does not
+  mention.
+- If the prose mentions a vague group (e.g. "the community", "research
+  directors"), still extract it as a named entity using the literal
+  phrase as the label. The author will resolve it to a specific
+  Person or Organization later.
+- If the section is empty or contains no extractable entities, return
+  empty arrays.
+- Be concise but faithful — the description fields should reflect what
+  the author wrote, not your interpretation.
+"""
+
+
+PROMPTS: dict[int, str] = {
+    2: SHARED_PREAMBLE
+    + """
+Question 2: Who are the stakeholders and what are their roles?
+
+Extract every distinct stakeholder mentioned. Each stakeholder pairs an
+actor (a person, organization, or group) with a role within the
+institution.
+
+For each:
+- role_label: the role the actor plays (e.g. "Editor", "Reviewer",
+  "Reader", "Founder").
+- agent_label: the actor as referenced in the prose (e.g. "Alice Chen",
+  "Metagov", "the community"). Use the most specific referent the prose
+  provides.
+- responsibilities: a short summary of what they do, if the prose says.
+  Otherwise null.
+
+Split distinct roles into distinct stakeholders even if the same actor
+appears (one record per role). Merge identical role + same actor pairs
+into one record.
+""",
+    3: SHARED_PREAMBLE
+    + """
+Question 3: What environmental factors shape the institution?
+
+Extract distinct environmental factors. Each factor is typed by one
+Lessig modality: Law, Norms, Markets, or Architecture.
+
+For each:
+- modality: which of Law/Norms/Markets/Architecture this falls under.
+- description: a sentence or two summarizing the factor as the author
+  describes it.
+
+Use the strictest applicable modality. Examples:
+- A statute or regulation → Law
+- A community expectation or convention → Norms
+- A pricing pressure, funding source, or marketplace → Markets
+- A technical infrastructure choice or architectural constraint → Architecture
+""",
+    4: SHARED_PREAMBLE
+    + """
+Question 4: What constitutes the institution's constitution?
+
+Extract distinct constitutional elements — formal or informal rules
+that generate institutional stability.
+
+For each:
+- label: a short name (e.g. "Charter", "Editorial review process").
+- description: how the rule operates.
+- element_type: one of Bylaw, Norm, DecisionProcedure,
+  DisputeResolution, AmendmentProcess.
+  - Bylaw: written formal rule (charter, terms, smart contract clause).
+  - Norm: unwritten convention.
+  - DecisionProcedure: how binding choices get made (voting, consensus).
+  - DisputeResolution: how conflicts get resolved.
+  - AmendmentProcess: how the institution's rules can change.
+- source_url: if the prose links to a canonical document for this
+  element, include the URL. Otherwise null.
+""",
+    5: SHARED_PREAMBLE
+    + """
+Question 5: Where are the field sites?
+
+Extract specific venues — physical or digital — where the institutional
+pattern can be observed.
+
+For each:
+- label: a short name (e.g. "GitHub repo", "Annual meeting").
+- url: if the prose gives a URL, include it; otherwise null.
+- description: any clarifying detail about what activity happens there.
+
+Do not include vague references ("online forums" with no URL or
+specifics). Do include named venues even without URLs.
+""",
+    6: SHARED_PREAMBLE
+    + """
+Question 6: What is your relationship to the institution?
+
+This question's prose is a singleton author disclosure, not a list.
+Extract:
+- author_label: the author's name as the prose identifies it. If the
+  prose is in first person without naming the author, return null.
+- author_role: the author's role in the institution (e.g. "founder",
+  "editor", "external observer").
+- disclosure: a faithful summary of the author's stated biases, blind
+  spots, conflicts of interest, or motivations for documenting.
+""",
+    7: SHARED_PREAMBLE
+    + """
+Question 7: How and when did the institution emerge?
+
+Extract distinct founding/origin events. Each event is a specific
+moment or short sequence of moments.
+
+For each:
+- label: short name (e.g. "Founding meeting", "Charter ratification").
+- description: what happened.
+- date: ISO date (YYYY or YYYY-MM-DD) if the prose specifies; otherwise null.
+- participant_labels: names of participants (people, orgs) the prose
+  identifies. The author will resolve these to specific People or
+  Organizations later.
+""",
+    8: SHARED_PREAMBLE
+    + """
+Question 8: How does the institution evolve?
+
+Extract distinct evolution mechanisms — procedures or recurring patterns
+through which the institution adapts.
+
+For each:
+- label: short name (e.g. "PR-driven amendment", "Annual review").
+- description: how the mechanism produces change.
+
+Distinct from constitutional elements (Q4): a Q8 mechanism is the
+*process* by which change happens, not the rule that constitutes
+governance at rest.
+""",
+    9: SHARED_PREAMBLE
+    + """
+Question 9: What references support this documentation?
+
+Extract every cited source. Treat references conservatively — only
+extract sources the prose explicitly cites, not background knowledge.
+
+For each:
+- title: the citation's title.
+- identifier: a DOI, URL, or other canonical identifier the prose
+  provides. If only a URL appears, use it as the identifier.
+- creators: list of named authors (one entry per author).
+- date: year or full date if given; otherwise null.
+""",
+}
+
+
+def system_prompt_for_question(question: int) -> str:
+    if question not in PROMPTS:
+        raise ValueError(f"no prompt for question {question}")
+    return PROMPTS[question]
+
+
+__all__ = ["SHARED_PREAMBLE", "PROMPTS", "system_prompt_for_question"]

--- a/src/mgj/parser/reconcile.py
+++ b/src/mgj/parser/reconcile.py
@@ -1,0 +1,89 @@
+"""
+mgj.parser.reconcile
+--------------------
+Reconciliation of new parser output against an existing instance graph.
+
+Today's invariant: parser-output entities for an *unaffirmed* question
+are dropped before re-extraction. Affirmed questions are protected by
+the affirmation guard in ``extract.run_extraction`` (the call is
+refused unless force=True), so reconciliation never touches affirmed
+entities.
+
+Drop semantics — for question Qi, remove every entity whose:
+- rdf:type matches the question's primary class, AND
+- carries a ``mgj:extractedBy`` link (i.e. was parser-emitted, not
+  hand-added via the CLI).
+
+The Submission's link triple to the entity is also removed.
+"""
+
+from __future__ import annotations
+
+from rdflib import Graph, URIRef
+from rdflib.namespace import RDF
+
+from mgj.namespaces import MGJ
+
+# Per-question owners: (entity OWL class, link predicate from Submission).
+QUESTION_OWNERS: dict[int, list[tuple[str, str]]] = {
+    2: [("Stakeholder", "hasStakeholder")],
+    3: [("EnvironmentalFactor", "hasEnvironmentalFactor")],
+    4: [("ConstitutionalElement", "hasConstitutionalElement")],
+    5: [("FieldSite", "hasFieldSite")],
+    6: [],  # Q6 sets singleton properties on the Submission, not n-ary entities.
+    7: [("OriginEvent", "hasOriginEvent")],
+    8: [("EvolutionMechanism", "hasEvolutionMechanism")],
+    9: [("Reference", "hasReference")],
+}
+
+
+def drop_parser_output_for_question(g: Graph, sub: URIRef, question: int) -> None:
+    """Remove parser-output entities for ``question`` from ``g``.
+
+    "Parser-output" means the entity carries an ``mgj:extractedBy``
+    triple. Hand-added entities (which lack that triple) are preserved.
+    """
+    owners = QUESTION_OWNERS.get(question, [])
+
+    # Find every parser-emitted entity once, then dispatch by class.
+    parser_entities = list(g.subjects(predicate=MGJ.extractedBy))
+
+    # Remove primary entities of the owned classes for this question.
+    owned_classes = {MGJ[cls] for cls, _ in owners}
+    link_preds_by_class = {MGJ[cls]: MGJ[link] for cls, link in owners}
+
+    for entity in parser_entities:
+        types = set(g.objects(entity, RDF.type))
+        matched_class = next(iter(types & owned_classes), None)
+        if matched_class is None:
+            continue
+        # Drop the Submission's link to this entity, then all triples about it.
+        g.remove((sub, link_preds_by_class[matched_class], entity))
+        for p, o in list(g.predicate_objects(entity)):
+            g.remove((entity, p, o))
+
+    # Drop any orphaned UnresolvedAgent that was a parser output for this Qi
+    # and is no longer referenced by anything.
+    if question in QUESTION_OWNERS:
+        _drop_orphan_unresolved_agents(g)
+
+
+def _drop_orphan_unresolved_agents(g: Graph) -> None:
+    """An UnresolvedAgent referenced by no Stakeholder, OriginEvent, or
+    other entity is orphaned — drop it. Only parser-output (mgj:extractedBy)
+    UAs are eligible for dropping."""
+    for ua in list(g.subjects(RDF.type, MGJ.UnresolvedAgent)):
+        if (ua, MGJ.extractedBy, None) not in g:
+            continue
+        referenced = (
+            any(g.subjects(MGJ.stakeholderAgent, ua))
+            or any(g.subjects(MGJ.originParticipant, ua))
+            or any(g.subjects(MGJ.authoredBy, ua))
+        )
+        if referenced:
+            continue
+        for p, o in list(g.predicate_objects(ua)):
+            g.remove((ua, p, o))
+
+
+__all__ = ["drop_parser_output_for_question", "QUESTION_OWNERS"]

--- a/src/mgj/parser/schemas.py
+++ b/src/mgj/parser/schemas.py
@@ -1,0 +1,218 @@
+"""
+mgj.parser.schemas
+------------------
+Per-question Pydantic schemas for parser output.
+
+These are *parser-output* models — what the LLM is asked to produce — not
+the canonical ``mgj.models``. The orchestration layer maps each parser
+output to canonical RDF triples in ``extract.py``. Keeping the two sets
+of models distinct lets us evolve the parser interface independently of
+the wire format.
+
+Each schema mirrors a single catechism question. The JSON-schema view
+(via ``model_json_schema()``) is what we hand to the backend's
+structured-output / tool-use API.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+NonEmptyStr = Annotated[str, Field(min_length=1)]
+
+
+# ---------------------------------------------------------------------------
+# Q2 — stakeholders
+# ---------------------------------------------------------------------------
+
+
+class ExtractedStakeholder(BaseModel):
+    role_label: NonEmptyStr = Field(
+        description="The stakeholder's role within the institution, e.g. 'Editor', 'Reviewer'."
+    )
+    agent_label: NonEmptyStr = Field(
+        description=(
+            "The literal phrase identifying the actor (e.g. 'Alice Chen', "
+            "'Metagov community'). The author will resolve this to a specific "
+            "Person or Organization later."
+        )
+    )
+    responsibilities: str | None = Field(
+        default=None,
+        description="Description of what this stakeholder is responsible for. Optional.",
+    )
+
+
+class Q2Extraction(BaseModel):
+    stakeholders: list[ExtractedStakeholder] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Q3 — environmental factors (Lessig-typed)
+# ---------------------------------------------------------------------------
+
+
+class ExtractedFactor(BaseModel):
+    modality: Literal["Law", "Norms", "Markets", "Architecture"] = Field(
+        description="Which Lessig modality this factor falls under."
+    )
+    description: NonEmptyStr = Field(
+        description="Description of the environmental force and how it shapes the institution."
+    )
+
+
+class Q3Extraction(BaseModel):
+    factors: list[ExtractedFactor] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Q4 — constitutional elements
+# ---------------------------------------------------------------------------
+
+
+class ExtractedConstitutionalElement(BaseModel):
+    label: NonEmptyStr = Field(
+        description="Short name for the rule, norm, or procedure."
+    )
+    description: NonEmptyStr
+    element_type: Literal[
+        "Bylaw",
+        "Norm",
+        "DecisionProcedure",
+        "DisputeResolution",
+        "AmendmentProcess",
+    ] = Field(description="Category of constitutional element.")
+    source_url: str | None = Field(
+        default=None,
+        description="Optional canonical URL for this element (charter doc, repo file).",
+    )
+
+
+class Q4Extraction(BaseModel):
+    elements: list[ExtractedConstitutionalElement] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Q5 — field sites
+# ---------------------------------------------------------------------------
+
+
+class ExtractedFieldSite(BaseModel):
+    label: NonEmptyStr
+    url: str | None = None
+    description: str | None = None
+
+
+class Q5Extraction(BaseModel):
+    field_sites: list[ExtractedFieldSite] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Q6 — author disclosure (singleton)
+# ---------------------------------------------------------------------------
+
+
+class Q6Extraction(BaseModel):
+    author_label: NonEmptyStr | None = Field(
+        default=None,
+        description="The author's name as it appears in the prose. Author resolves to a Person.",
+    )
+    author_role: str | None = None
+    disclosure: str | None = Field(
+        default=None,
+        description="Disclosure of biases, blind spots, or motivations.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Q7 — origin events
+# ---------------------------------------------------------------------------
+
+
+class ExtractedOriginEvent(BaseModel):
+    label: NonEmptyStr
+    description: NonEmptyStr
+    date: str | None = Field(
+        default=None,
+        description="ISO 8601 date if specifiable (YYYY or YYYY-MM-DD); otherwise null.",
+    )
+    participant_labels: list[str] = Field(
+        default_factory=list,
+        description="Names of participants. Author resolves these to People/Orgs later.",
+    )
+
+
+class Q7Extraction(BaseModel):
+    events: list[ExtractedOriginEvent] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Q8 — evolution mechanisms
+# ---------------------------------------------------------------------------
+
+
+class ExtractedEvolutionMechanism(BaseModel):
+    label: NonEmptyStr
+    description: NonEmptyStr
+
+
+class Q8Extraction(BaseModel):
+    mechanisms: list[ExtractedEvolutionMechanism] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Q9 — references
+# ---------------------------------------------------------------------------
+
+
+class ExtractedReference(BaseModel):
+    title: NonEmptyStr
+    identifier: NonEmptyStr = Field(description="DOI or canonical URL.")
+    creators: list[str] = Field(default_factory=list)
+    date: str | None = None
+
+
+class Q9Extraction(BaseModel):
+    references: list[ExtractedReference] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Mapping: question number → schema
+# ---------------------------------------------------------------------------
+
+EXTRACTION_SCHEMAS: dict[int, type[BaseModel]] = {
+    2: Q2Extraction,
+    3: Q3Extraction,
+    4: Q4Extraction,
+    5: Q5Extraction,
+    6: Q6Extraction,
+    7: Q7Extraction,
+    8: Q8Extraction,
+    9: Q9Extraction,
+}
+"""Q1 has no typed entities (narrative-only). All other questions have a schema."""
+
+QUESTIONS_WITH_ENTITIES = sorted(EXTRACTION_SCHEMAS.keys())
+
+
+__all__ = [
+    "ExtractedStakeholder",
+    "Q2Extraction",
+    "ExtractedFactor",
+    "Q3Extraction",
+    "ExtractedConstitutionalElement",
+    "Q4Extraction",
+    "ExtractedFieldSite",
+    "Q5Extraction",
+    "Q6Extraction",
+    "ExtractedOriginEvent",
+    "Q7Extraction",
+    "ExtractedEvolutionMechanism",
+    "Q8Extraction",
+    "ExtractedReference",
+    "Q9Extraction",
+    "EXTRACTION_SCHEMAS",
+    "QUESTIONS_WITH_ENTITIES",
+]

--- a/src/mgj/serialize.py
+++ b/src/mgj/serialize.py
@@ -1,0 +1,258 @@
+"""
+mgj.serialize
+-------------
+Pydantic Submission → rdflib Graph.
+
+One-direction serialization. The graph is the source of truth at rest;
+Pydantic models are the typed authoring/parser interface that the CLI
+and parser layers use to construct content. The CLI's read paths use
+SPARQL against the loaded graph rather than re-deserializing the whole
+submission into a model.
+
+Output is deterministic for a given input model: triples are added in a
+fixed order, and rdflib's Turtle serializer normalizes prefix ordering
+in the final output. This is a prerequisite for the compilation
+determinism invariant.
+"""
+
+from __future__ import annotations
+
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import DCTERMS, FOAF, RDF, RDFS, SKOS, XSD
+
+from mgj.models import (
+    ConstitutionalElement,
+    EnvironmentalFactor,
+    EvolutionMechanism,
+    FieldSite,
+    Institution,
+    LegalContext,
+    OriginEvent,
+    Organization,
+    Person,
+    Reference,
+    Stakeholder,
+    Submission,
+    UnresolvedAgent,
+)
+from mgj.namespaces import MGJ
+
+
+def _u(iri: str) -> URIRef:
+    return URIRef(iri)
+
+
+def _mgj(local: str) -> URIRef:
+    return MGJ[local]
+
+
+# ---------------------------------------------------------------------------
+# Shared agents
+# ---------------------------------------------------------------------------
+
+
+def add_person(g: Graph, p: Person) -> None:
+    node = _u(p.iri)
+    g.add((node, RDF.type, FOAF.Person))
+    g.add((node, FOAF.name, Literal(p.name)))
+    if p.homepage is not None:
+        g.add((node, FOAF.homepage, Literal(str(p.homepage), datatype=XSD.anyURI)))
+
+
+def add_organization(g: Graph, o: Organization) -> None:
+    node = _u(o.iri)
+    g.add((node, RDF.type, FOAF.Organization))
+    g.add((node, FOAF.name, Literal(o.name)))
+    if o.homepage is not None:
+        g.add((node, FOAF.homepage, Literal(str(o.homepage), datatype=XSD.anyURI)))
+
+
+def add_unresolved_agent(g: Graph, u: UnresolvedAgent) -> None:
+    node = _u(u.iri)
+    g.add((node, RDF.type, _mgj("UnresolvedAgent")))
+    g.add((node, _mgj("unresolvedLabel"), Literal(u.label)))
+
+
+# ---------------------------------------------------------------------------
+# Institution
+# ---------------------------------------------------------------------------
+
+
+def add_institution(g: Graph, i: Institution) -> None:
+    node = _u(i.iri)
+    g.add((node, RDF.type, _mgj("Institution")))
+    g.add((node, _mgj("institutionName"), Literal(i.name)))
+    if i.description is not None:
+        g.add((node, _mgj("institutionDescription"), Literal(i.description)))
+
+
+# ---------------------------------------------------------------------------
+# Per-question entities
+# ---------------------------------------------------------------------------
+
+
+def add_stakeholder(g: Graph, s: Stakeholder) -> None:
+    node = _u(s.iri)
+    g.add((node, RDF.type, _mgj("Stakeholder")))
+    g.add((node, _mgj("stakeholderAgent"), _u(s.agent_iri)))
+    g.add((node, _mgj("roleLabel"), Literal(s.role_label)))
+    if s.role_iri is not None:
+        g.add((node, _mgj("hasRole"), _u(s.role_iri)))
+    if s.responsibilities is not None:
+        g.add((node, _mgj("stakeholderResponsibilities"), Literal(s.responsibilities)))
+
+
+def add_field_site(g: Graph, f: FieldSite) -> None:
+    node = _u(f.iri)
+    g.add((node, RDF.type, _mgj("FieldSite")))
+    g.add((node, _mgj("fieldSiteLabel"), Literal(f.label)))
+    if f.url is not None:
+        g.add((node, _mgj("fieldSiteURL"), Literal(str(f.url), datatype=XSD.anyURI)))
+    if f.description is not None:
+        g.add((node, _mgj("fieldSiteDescription"), Literal(f.description)))
+
+
+def add_environmental_factor(g: Graph, e: EnvironmentalFactor) -> None:
+    node = _u(e.iri)
+    g.add((node, RDF.type, _mgj("EnvironmentalFactor")))
+    g.add((node, _mgj("lessigModality"), _mgj(e.modality)))
+    g.add((node, _mgj("factorDescription"), Literal(e.description)))
+
+
+def add_constitutional_element(g: Graph, c: ConstitutionalElement) -> None:
+    node = _u(c.iri)
+    g.add((node, RDF.type, _mgj("ConstitutionalElement")))
+    g.add((node, _mgj("elementLabel"), Literal(c.label)))
+    g.add((node, _mgj("elementDescription"), Literal(c.description)))
+    g.add((node, _mgj("elementType"), _mgj(c.element_type)))
+    if c.source_url is not None:
+        g.add(
+            (node, _mgj("elementSourceURL"), Literal(str(c.source_url), datatype=XSD.anyURI))
+        )
+
+
+def add_origin_event(g: Graph, o: OriginEvent) -> None:
+    node = _u(o.iri)
+    g.add((node, RDF.type, _mgj("OriginEvent")))
+    g.add((node, _mgj("originLabel"), Literal(o.label)))
+    g.add((node, _mgj("originDescription"), Literal(o.description)))
+    if o.date is not None:
+        g.add((node, _mgj("originDate"), Literal(o.date.isoformat(), datatype=XSD.date)))
+    for p_iri in o.participant_iris:
+        g.add((node, _mgj("originParticipant"), _u(p_iri)))
+
+
+def add_evolution_mechanism(g: Graph, m: EvolutionMechanism) -> None:
+    node = _u(m.iri)
+    g.add((node, RDF.type, _mgj("EvolutionMechanism")))
+    g.add((node, _mgj("mechanismLabel"), Literal(m.label)))
+    g.add((node, _mgj("mechanismDescription"), Literal(m.description)))
+
+
+def add_reference(g: Graph, r: Reference) -> None:
+    node = _u(r.iri)
+    g.add((node, RDF.type, _mgj("Reference")))
+    g.add((node, DCTERMS.title, Literal(r.title)))
+    g.add((node, DCTERMS.identifier, Literal(r.identifier)))
+    if r.date is not None:
+        g.add((node, DCTERMS.date, Literal(r.date)))
+    for c in r.creators:
+        g.add((node, DCTERMS.creator, Literal(c)))
+
+
+def add_legal_context(g: Graph, l: LegalContext) -> None:
+    node = _u(l.iri)
+    g.add((node, RDF.type, _mgj("LegalContext")))
+    g.add((node, _mgj("hostOrganization"), _u(l.host_organization_iri)))
+    g.add((node, _mgj("legalRelationship"), _mgj(l.legal_relationship)))
+    g.add((node, _mgj("legalContextDescription"), Literal(l.description)))
+    if l.funding_reference is not None:
+        g.add((node, _mgj("fundingReference"), Literal(l.funding_reference)))
+
+
+# ---------------------------------------------------------------------------
+# Submission
+# ---------------------------------------------------------------------------
+
+
+def add_submission(g: Graph, s: Submission) -> None:
+    node = _u(s.iri)
+    g.add((node, RDF.type, _mgj("Submission")))
+    g.add((node, _mgj("documents"), _u(s.institution_iri)))
+    g.add(
+        (node, _mgj("submissionDate"), Literal(s.submission_date.isoformat(), datatype=XSD.date))
+    )
+    g.add((node, _mgj("submissionVersion"), Literal(s.submission_version)))
+
+    # Q6 author disclosure
+    if s.author_iri is not None:
+        g.add((node, _mgj("authoredBy"), _u(s.author_iri)))
+    if s.author_role is not None:
+        g.add((node, _mgj("authorRole"), Literal(s.author_role)))
+    if s.author_disclosure is not None:
+        g.add((node, _mgj("authorDisclosure"), Literal(s.author_disclosure)))
+
+    # Per-question narratives
+    narratives = [
+        (s.q1_narrative, "q1Narrative"),
+        (s.q2_narrative, "q2Narrative"),
+        (s.q3_narrative, "q3Narrative"),
+        (s.q4_narrative, "q4Narrative"),
+        (s.q5_narrative, "q5Narrative"),
+        (s.q6_narrative, "q6Narrative"),
+        (s.q7_narrative, "q7Narrative"),
+        (s.q8_narrative, "q8Narrative"),
+        (s.q9_narrative, "q9Narrative"),
+    ]
+    for value, prop in narratives:
+        if value is not None:
+            g.add((node, _mgj(prop), Literal(value)))
+
+    # Per-question entity links
+    for st in s.stakeholders:
+        add_stakeholder(g, st)
+        g.add((node, _mgj("hasStakeholder"), _u(st.iri)))
+    for ef in s.environmental_factors:
+        add_environmental_factor(g, ef)
+        g.add((node, _mgj("hasEnvironmentalFactor"), _u(ef.iri)))
+    for ce in s.constitutional_elements:
+        add_constitutional_element(g, ce)
+        g.add((node, _mgj("hasConstitutionalElement"), _u(ce.iri)))
+    for fs in s.field_sites:
+        add_field_site(g, fs)
+        g.add((node, _mgj("hasFieldSite"), _u(fs.iri)))
+    for oe in s.origin_events:
+        add_origin_event(g, oe)
+        g.add((node, _mgj("hasOriginEvent"), _u(oe.iri)))
+    for em in s.evolution_mechanisms:
+        add_evolution_mechanism(g, em)
+        g.add((node, _mgj("hasEvolutionMechanism"), _u(em.iri)))
+    for ref in s.references:
+        add_reference(g, ref)
+        g.add((node, _mgj("hasReference"), _u(ref.iri)))
+
+    if s.legal_context is not None:
+        add_legal_context(g, s.legal_context)
+        g.add((node, _mgj("operatesUnder"), _u(s.legal_context.iri)))
+
+    for ua in s.unresolved_agents:
+        add_unresolved_agent(g, ua)
+
+
+def submission_to_graph(s: Submission, institution: Institution | None = None) -> Graph:
+    """Serialize a Submission to a fresh, namespace-bound Graph.
+
+    If ``institution`` is provided, the institution's triples are added
+    (useful for tests / first-time scaffolding). In normal flows the
+    institution lives in shared/ and is loaded from there.
+    """
+    g = Graph()
+    g.bind("mgj", MGJ)
+    g.bind("foaf", FOAF)
+    g.bind("dcterms", DCTERMS)
+    g.bind("skos", SKOS)
+    g.bind("rdfs", RDFS)
+    if institution is not None:
+        add_institution(g, institution)
+    add_submission(g, s)
+    return g

--- a/src/mgj/validate.py
+++ b/src/mgj/validate.py
@@ -1,0 +1,168 @@
+"""
+mgj.validate
+------------
+SHACL validation wrapper.
+
+Two modes:
+
+- ``validate(graph, mode="system")`` runs the full system shapes graph,
+  enforcing cardinality, integrity, and the no-UnresolvedAgent rule. This
+  is the gate the outer loop ("Conform") clears before compilation.
+
+- ``validate(graph, mode="per_question", question=N)`` runs only the
+  shapes for that question (q{N}-*.ttl). This is the inner-loop check
+  invoked after every CLI mutation.
+
+The data graph passed in must already include shared registries, so
+SHACL ``sh:class foaf:Person`` constraints can resolve. The ontology is
+loaded as ``ont_graph`` so SHACL can resolve class hierarchies during
+validation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from pyshacl import validate as _pyshacl_validate
+from rdflib import Graph
+
+from mgj.graph import (
+    load_ontology,
+    load_per_question_shapes,
+    load_system_shapes,
+)
+
+
+Mode = Literal["per_question", "system"]
+
+
+@dataclass(frozen=True)
+class ValidationViolation:
+    focus_node: str
+    result_path: str
+    message: str
+    severity: str
+    source_shape: str
+
+
+@dataclass
+class ValidationReport:
+    conforms: bool
+    violations: list[ValidationViolation] = field(default_factory=list)
+    raw_report: str = ""
+
+    @property
+    def violation_count(self) -> int:
+        return len(self.violations)
+
+    def __str__(self) -> str:
+        if self.conforms:
+            return "OK: graph conforms"
+        lines = [f"FAIL: {self.violation_count} violation(s)"]
+        for v in self.violations:
+            lines.append(f"  [{v.severity.split('#')[-1]}] focus={v.focus_node}")
+            if v.result_path:
+                lines.append(f"    path: {v.result_path}")
+            if v.message:
+                lines.append(f"    msg:  {v.message}")
+        return "\n".join(lines)
+
+
+def _parse_report(report_graph: Graph) -> list[ValidationViolation]:
+    q = """
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    SELECT ?focusNode ?resultPath ?message ?severity ?sourceShape
+    WHERE {
+      ?r a sh:ValidationResult ;
+         sh:focusNode      ?focusNode ;
+         sh:resultSeverity ?severity ;
+         sh:sourceShape    ?sourceShape .
+      OPTIONAL { ?r sh:resultPath    ?resultPath }
+      OPTIONAL { ?r sh:resultMessage ?message }
+    }
+    """
+    violations: list[ValidationViolation] = []
+    for row in report_graph.query(q):
+        violations.append(
+            ValidationViolation(
+                focus_node=str(row.focusNode),
+                result_path=str(row.resultPath) if row.resultPath else "",
+                message=str(row.message) if row.message else "",
+                severity=str(row.severity),
+                source_shape=str(row.sourceShape),
+            )
+        )
+    return violations
+
+
+def validate(
+    data_graph: Graph,
+    *,
+    mode: Mode = "system",
+    question: int | None = None,
+) -> ValidationReport:
+    """Validate ``data_graph`` against the appropriate SHACL shapes.
+
+    Parameters
+    ----------
+    data_graph
+        The submission graph. Should already include shared registries
+        (people, orgs) so foaf:Person / foaf:Organization references resolve.
+    mode
+        ``"system"`` runs the full system shapes; ``"per_question"`` runs
+        the shapes for the given question only.
+    question
+        Required when ``mode="per_question"``; ignored otherwise.
+    """
+    if mode == "per_question":
+        if question is None:
+            raise ValueError("question is required when mode='per_question'")
+        shapes = load_per_question_shapes(question)
+    elif mode == "system":
+        shapes = load_system_shapes()
+    else:
+        raise ValueError(f"unknown mode: {mode!r}")
+
+    ontology = load_ontology()
+
+    conforms, report_graph, report_text = _pyshacl_validate(
+        data_graph,
+        shacl_graph=shapes,
+        ont_graph=ontology,
+        inference="none",
+        abort_on_first=False,
+        serialize_report_graph=False,
+        advanced=True,
+    )
+
+    return ValidationReport(
+        conforms=bool(conforms),
+        violations=_parse_report(report_graph),
+        raw_report=report_text,
+    )
+
+
+def validate_file(
+    path: str | Path,
+    *,
+    mode: Mode = "system",
+    question: int | None = None,
+    with_shared: bool = True,
+) -> ValidationReport:
+    """Load ``path`` and validate. ``with_shared`` controls whether shared
+    registries are merged before validation."""
+    from mgj.graph import load_instance
+
+    data_graph = load_instance(path, with_shared=with_shared)
+    return validate(data_graph, mode=mode, question=question)
+
+
+__all__ = [
+    "Mode",
+    "ValidationViolation",
+    "ValidationReport",
+    "validate",
+    "validate_file",
+]

--- a/submissions/metagov-journal/compiled.md
+++ b/submissions/metagov-journal/compiled.md
@@ -1,0 +1,103 @@
+# The Metagov Journal
+
+*Submission v1.0.0 — 2026-04-25*
+
+<!-- compiler: mgj.compilers.catechism v0.1.0 -->
+
+## 1. Purpose
+
+The Metagov Journal produces and maintains a peer-reviewed commons of institutional knowledge. Its stable pattern involves practitioners documenting living institutions through structured catechisms, peers reviewing these documentations for completeness and clarity, and the community accumulating reusable organizational patterns. Success manifests as a growing repository of institutional specifications that practitioners reference when designing new organizations or evolving existing ones. The institution functions properly when submissions flow regularly, reviews maintain quality standards, and documented patterns get reused across contexts.
+
+## 2. Stakeholders and roles
+
+Authors document institutions they understand deeply, answering the catechism and providing supporting materials. Reviewers evaluate submissions for completeness, clarity, and contribution to knowledge. Editors (initially Joshua Tan as lead, with Michael Zargham) coordinate review processes, make publication decisions, and maintain infrastructure. Readers access documented patterns for learning and adaptation. Metagov provides organizational home and alignment with digital self-governance mission, with research directors Seth Frey and Ellie Rennie providing oversight.
+
+### Stakeholders
+
+- **Editor**: Joshua Tan — Lead editor; coordinates review and publication.
+- **Editor**: Michael Zargham — Co-editor; infrastructure and operations.
+- **Research Director**: Seth Frey — Provides oversight; cognitive-science perspective.
+- **Research Director**: Ellie Rennie — Provides oversight; digital-ethnography perspective.
+- **Organizational Home**: Metagov — Provides nonprofit infrastructure and mission alignment.
+
+## 3. Environmental factors
+
+The journal operates within overlapping contexts. Technically, it depends on GitHub for version control and collaboration, technical platforms for archival storage and DOIs. Academically, it bridges scholarly publishing conventions with open-source software practices. Legally, it operates under Metagov's nonprofit structure. Normatively, it inherits from both peer review traditions and GitHub collaboration patterns. Economically, it functions as a scholarly club good where contribution enables access to curated knowledge.
+
+### Law
+
+- Operates under Metagov's nonprofit structure; subject to nonprofit governance regulation.
+
+### Norms
+
+- Inherits scholarly peer-review traditions and open-source GitHub collaboration patterns.
+
+### Markets
+
+- Functions as a scholarly club good: contribution enables access to curated knowledge.
+
+### Architecture
+
+- GitHub provides version control, peer-review tooling, and collaboration infrastructure.
+
+## 4. Constitution
+
+The foundational rules emerge from three layers. The Catechism (nine questions) structures all submissions, creating comparable documentation. The Review Criteria define evaluation standards — completeness, clarity, evidence, viability, and contribution. The GitHub Flow establishes procedural rules — fork, submit PR, review, revise, merge.
+
+### Bylaw
+
+- **Catechism**: Nine-question framework that structures every submission, creating comparable documentation.
+- **Review Criteria**: Evaluation standards — completeness, clarity, evidence, viability, contribution.
+
+### Norm
+
+- **Editorial Norms**: Constructive feedback tone, reasonable review timelines, transparency in decision-making.
+
+### Decision Procedure
+
+- **GitHub Flow**: Procedural rules — fork, submit PR, review, revise, merge.
+
+## 5. Field sites
+
+Primary activity occurs at github.com/metagov/journal — submissions, reviews, and discussions. The Metagov website offers organizational context. Joshua Tan's introductory blog post articulates the founding vision.
+
+- [GitHub repository](https://github.com/metagov/metagov-journal) — Primary site for submissions, reviews, and discussion.
+- [Metagov website](https://metagov.org) — Organizational home and mission context.
+- [Founding blog post](https://journal.metagov.org/2025/08/09/metagov-journal.html) — Joshua Tan's introductory articulation of the journal's vision.
+
+## 6. Author relationship
+
+As author of this draft, I am a systems engineer and protocol architect with deep experience in open source communities — my role in Metagov is often to map systems and provide operational policy recommendations. Joshua Tan, Metagov co-founder and journal's primary driver, provides vision and organizational support. We both serve on Metagov's board, creating alignment but also potential conflicts of interest.
+
+*Authored by **Michael Zargham** — co-editor and board member.*
+
+*Disclosure:* Author serves on Metagov's board with Joshua Tan; potential conflict of interest. Bootstrap submission receives review from fellow research directors rather than external reviewers. Blind spots likely include overemphasis on technical mechanisms.
+
+## 7. Origins
+
+The journal emerged from Joshua Tan's observation that governance experiments in DAOs, cooperatives, and digital communities generate valuable innovations but lack documentation venues. In late 2024, Tan convened Metagov research directors to design a solution. The founding team brought complementary perspectives: Tan (platform governance), Zargham (systems engineering), Frey (cognitive science), Rennie (digital ethnography).
+
+- **Founding convening** (2024-11-01): In late 2024, Joshua Tan convened Metagov research directors to design a journal for documenting living institutions. — *participants: Ellie Rennie, Joshua Tan, Michael Zargham, Seth Frey*
+
+## 8. Evolution
+
+Evolution operates through multiple mechanisms. Immediate adaptation happens via GitHub. Periodic review occurs quarterly as editors assess processes and incorporate lessons. Version control enables framework evolution while maintaining citation stability through semantic versioning. Community feedback shapes development through discussions and reviews. Scaling triggers activate new processes as volume grows.
+
+- **PR-driven amendment**: Anyone can propose changes to framework documents through GitHub issues and pull requests.
+- **Quarterly editorial review**: Editors assess processes and incorporate lessons each quarter.
+- **Semantic versioning**: Framework evolution preserves citation stability via versioned releases.
+
+## Legal context
+
+*Operates under **Metagov** as fiscal sponsor.*
+
+The journal operates under Metagov's 501(c)(3) nonprofit infrastructure.
+
+## 9. References
+
+Foundational documents and academic references that ground the journal's design and motivate its operating model.
+
+1. Joshua Tan (2025). [Introducing the Metagov Journal](https://journal.metagov.org/2025/08/09/metagov-journal.html)
+2. Ilan Ben-Meir, Michael Zargham (2024). [Protocols and Institutions](https://zenodo.org/records/15122312)
+3. Michael Zargham (2023). [What Constitutes a Constitution](https://zenodo.org/records/10609125)
+4. Jason Potts (2017). [A Journal is a Club](https://www.tandfonline.com/doi/abs/10.1080/08109028.2017.1386949)

--- a/submissions/metagov-journal/extraction-trace.json
+++ b/submissions/metagov-journal/extraction-trace.json
@@ -1,0 +1,16 @@
+{
+  "affirmed_questions": {
+    "1": null,
+    "2": null,
+    "3": null,
+    "4": null,
+    "5": null,
+    "6": null,
+    "7": null,
+    "8": null,
+    "9": null
+  },
+  "extractions": [],
+  "slug": "metagov-journal",
+  "version": "1.0.0"
+}

--- a/submissions/metagov-journal/input.md
+++ b/submissions/metagov-journal/input.md
@@ -1,0 +1,44 @@
+# Institutional Specification: The Metagov Journal
+
+*This document serves as both the inaugural submission and exemplar for the journal's documentation framework.*
+
+## 1. What is the institution's purpose?
+
+The Metagov Journal produces and maintains a peer-reviewed commons of institutional knowledge. Its stable pattern involves practitioners documenting living institutions through structured catechisms, peers reviewing these documentations for completeness and clarity, and the community accumulating reusable organizational patterns. Success manifests as a growing repository of institutional specifications that practitioners reference when designing new organizations or evolving existing ones. The institution functions properly when submissions flow regularly, reviews maintain quality standards, and documented patterns get reused across contexts.
+
+## 2. Who are the stakeholders and what are their roles?
+
+**Authors** document institutions they understand deeply, answering the catechism and providing supporting materials. **Reviewers** evaluate submissions for completeness, clarity, and contribution to knowledge. **Editors** (initially Joshua Tan as lead, with Michael Zargham) coordinate review processes, make publication decisions, and maintain infrastructure. **Readers** access documented patterns for learning and adaptation. **Metagov** provides organizational home and alignment with digital self-governance mission, with research directors Seth Frey and Ellie Rennie providing oversight. Participation is open—anyone can submit, experienced practitioners become reviewers, and active contributors join editorial roles.
+
+## 3. What environmental factors shape the institution?
+
+The journal operates within overlapping contexts. **Technically**, it depends on GitHub for version control and collaboration, technical platforms for archival storage and DOIs. **Academically**, it bridges scholarly publishing conventions with open-source software practices. **Legally**, it operates under Metagov's nonprofit structure. **Normatively**, it inherits from both peer review traditions and GitHub collaboration patterns. Many community members at Metagov feel their work falls between the disciplanary cracks, and that a site for publication is needed -- a more agile and interdisciplanary site for publication has long be desired within Metagov. Although it has been difficult to formalize well enough to operationalize the idea. **Economically**, it functions as a scholarly club good where contribution enables access to curated knowledge. The predominant constraints are volunteer labor availability and the challenge of establishing legitimacy in a novel publishing category. The operational overhead falls within the broader operations of the Metagov non-profit. The need to demonstrate impact for past and future funders impacts the incentives to deploy and operate a journal.
+
+## 4. What constitutes the institution's constitution?
+
+The foundational rules emerge from three layers. **The Catechism** (nine questions) structures all submissions, creating comparable documentation. **The Review Criteria** define evaluation standards—completeness, clarity, evidence, viability, and contribution. **The GitHub Flow** establishes procedural rules—fork, submit PR, review, revise, merge. These formal protocols interact with informal norms developing through practice: constructive feedback tone, reasonable review timelines, and transparency in decision-making. Constitutional change happens through pull requests to framework documents, discussed publicly and merged by editors. This constitution is deliberately minimal, allowing practices to emerge through use.
+
+## 5. Where are the field sites?
+
+The institution operates across connected venues. Primary activity occurs at [github.com/metagov/journal](https://github.com/metagov/journal)—submissions, reviews, and discussions. The `<preprint server/overlay journal>` provides stable citations. The [Metagov website](https://metagov.org) offers organizational context. Joshua Tan's [introductory blog post](https://journal.metagov.org/2025/08/09/metagov-journal.html) articulates the founding vision. Future sites may include dedicated web interface for browsing submissions and overlay journal services for enhanced discovery. Each venue serves different stakeholder needs while maintaining coherent institutional identity.
+
+## 6. What is your relationship to the institution?
+
+As author (Michael Zargham) of this draft, I am a systems engineer and protocol architect with deep experience in open source communities -- my role i Metagov is often to map systems and provide operational policy recommendations. Joshua Tan, Metagov co-founder and journal's primary driver, provides vision and organizational support. We both serve on Metagov's board, creating alignment but also potential conflicts of interest. This bootstrap submission receives review from fellow research directors rather than external reviewers. My perspective is shaped by complex systems background and previous work on institutional design. Blind spots likely include overemphasis on technical mechanisms and limited view of reader experiences. This documentation itself is performative—simultaneously creating and describing the institution.
+
+## 7. How was the institution founded?
+
+The journal emerged from Joshua Tan's observation that governance experiments in DAOs, cooperatives, and digital communities generate valuable innovations but lack documentation venues. Traditional academic publishing captures research *about* institutions but not institutional *designs themselves*. In late 2024, Tan convened Metagov research directors to design a solution. The founding team brought complementary perspectives: Tan (platform governance), Zargham (systems engineering), Frey (cognitive science), Rennie (digital ethnography). Initial development leveraged Metagov's existing infrastructure and networks. The catechism framework emerged through iterative design, balancing academic rigor with practitioner accessibility. This self-submission launches the journal, demonstrating viability through self-application.
+
+## 8. How does the institution evolve?
+
+Evolution operates through multiple mechanisms. **Immediate adaptation** happens via GitHub—anyone can propose changes through issues and pull requests. **Periodic review** occurs quarterly as editors assess processes and incorporate lessons. **Version control** enables framework evolution while maintaining citation stability through semantic versioning. **Community feedback** shapes development through discussions and reviews. **Scaling triggers** activate new processes as volume grows—additional editors, automated checks, section specialization. The institution learns through each submission cycle, accumulating both content (documented institutions) and meta-knowledge (documentation practices). The living repository layer enables continuous evolution while the archival layer preserves scholarly record.
+
+## 9. What references support this documentation?
+
+- Tan, J. (2025). ["Introducing the Metagov Journal"](https://journal.metagov.org/2025/08/09/metagov-journal.html) - Founding vision and motivation
+- [GitHub Repository](https://github.com/metagov/metagov-journal) - Living infrastructure and version history
+- [Metagov Organization](https://metagov.org) - Organizational home and mission alignment
+- Zargham & Ben-Meir (2024). ["Protocols and Institutions"](https://zenodo.org/records/15122312) - Institutional Economics and Cybernetcs.
+- Zargham et al. (2023). ["What Constitutes a Constitution"](https://zenodo.org/records/10609125) - Intersection between technology and legal theory.
+- Potts et al. (2017). ["A Journal is a Club"](https://www.tandfonline.com/doi/abs/10.1080/08109028.2017.1386949) - Initiates the discussion of a journal in institutional economic terms.

--- a/submissions/metagov-journal/instance.ttl
+++ b/submissions/metagov-journal/instance.ttl
@@ -1,0 +1,261 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX mgj: <https://journal.metagov.org/ns/mgj#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0>
+    a mgj:Submission ;
+    mgj:authorDisclosure "Author serves on Metagov's board with Joshua Tan; potential conflict of interest. Bootstrap submission receives review from fellow research directors rather than external reviewers. Blind spots likely include overemphasis on technical mechanisms." ;
+    mgj:authorRole "co-editor and board member" ;
+    mgj:authoredBy <https://journal.metagov.org/people/michael-zargham> ;
+    mgj:documents <https://journal.metagov.org/institutions/metagov-journal> ;
+    mgj:hasConstitutionalElement
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/constitution/1> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/constitution/2> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/constitution/3> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/constitution/4> ;
+    mgj:hasEnvironmentalFactor
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/factor/1> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/factor/2> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/factor/3> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/factor/4> ;
+    mgj:hasEvolutionMechanism
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/evolution/1> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/evolution/2> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/evolution/3> ;
+    mgj:hasFieldSite
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/fieldsite/1> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/fieldsite/2> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/fieldsite/3> ;
+    mgj:hasOriginEvent <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/origin/1> ;
+    mgj:hasReference
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/reference/1> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/reference/2> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/reference/3> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/reference/4> ;
+    mgj:hasStakeholder
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/1> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/2> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/3> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/4> ,
+        <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/5> ;
+    mgj:operatesUnder <https://journal.metagov.org/submissions/metagov-journal/v1.0.0/legal/1> ;
+    mgj:q1Narrative "The Metagov Journal produces and maintains a peer-reviewed commons of institutional knowledge. Its stable pattern involves practitioners documenting living institutions through structured catechisms, peers reviewing these documentations for completeness and clarity, and the community accumulating reusable organizational patterns. Success manifests as a growing repository of institutional specifications that practitioners reference when designing new organizations or evolving existing ones. The institution functions properly when submissions flow regularly, reviews maintain quality standards, and documented patterns get reused across contexts." ;
+    mgj:q2Narrative "Authors document institutions they understand deeply, answering the catechism and providing supporting materials. Reviewers evaluate submissions for completeness, clarity, and contribution to knowledge. Editors (initially Joshua Tan as lead, with Michael Zargham) coordinate review processes, make publication decisions, and maintain infrastructure. Readers access documented patterns for learning and adaptation. Metagov provides organizational home and alignment with digital self-governance mission, with research directors Seth Frey and Ellie Rennie providing oversight." ;
+    mgj:q3Narrative "The journal operates within overlapping contexts. Technically, it depends on GitHub for version control and collaboration, technical platforms for archival storage and DOIs. Academically, it bridges scholarly publishing conventions with open-source software practices. Legally, it operates under Metagov's nonprofit structure. Normatively, it inherits from both peer review traditions and GitHub collaboration patterns. Economically, it functions as a scholarly club good where contribution enables access to curated knowledge." ;
+    mgj:q4Narrative "The foundational rules emerge from three layers. The Catechism (nine questions) structures all submissions, creating comparable documentation. The Review Criteria define evaluation standards — completeness, clarity, evidence, viability, and contribution. The GitHub Flow establishes procedural rules — fork, submit PR, review, revise, merge." ;
+    mgj:q5Narrative "Primary activity occurs at github.com/metagov/journal — submissions, reviews, and discussions. The Metagov website offers organizational context. Joshua Tan's introductory blog post articulates the founding vision." ;
+    mgj:q6Narrative "As author of this draft, I am a systems engineer and protocol architect with deep experience in open source communities — my role in Metagov is often to map systems and provide operational policy recommendations. Joshua Tan, Metagov co-founder and journal's primary driver, provides vision and organizational support. We both serve on Metagov's board, creating alignment but also potential conflicts of interest." ;
+    mgj:q7Narrative "The journal emerged from Joshua Tan's observation that governance experiments in DAOs, cooperatives, and digital communities generate valuable innovations but lack documentation venues. In late 2024, Tan convened Metagov research directors to design a solution. The founding team brought complementary perspectives: Tan (platform governance), Zargham (systems engineering), Frey (cognitive science), Rennie (digital ethnography)." ;
+    mgj:q8Narrative "Evolution operates through multiple mechanisms. Immediate adaptation happens via GitHub. Periodic review occurs quarterly as editors assess processes and incorporate lessons. Version control enables framework evolution while maintaining citation stability through semantic versioning. Community feedback shapes development through discussions and reviews. Scaling triggers activate new processes as volume grows." ;
+    mgj:q9Narrative "Foundational documents and academic references that ground the journal's design and motivate its operating model." ;
+    mgj:submissionDate "2026-04-25"^^xsd:date ;
+    mgj:submissionVersion "1.0.0" ;
+.
+
+<https://journal.metagov.org/institutions/metagov-journal>
+    a mgj:Institution ;
+    mgj:institutionName "The Metagov Journal" ;
+.
+
+<https://journal.metagov.org/roles/organizational-home>
+    a skos:Concept ;
+    skos:inScheme mgj:RoleType ;
+    skos:prefLabel "Organizational Home" ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/constitution/1>
+    a mgj:ConstitutionalElement ;
+    mgj:elementDescription "Nine-question framework that structures every submission, creating comparable documentation." ;
+    mgj:elementLabel "Catechism" ;
+    mgj:elementType mgj:Bylaw ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/constitution/2>
+    a mgj:ConstitutionalElement ;
+    mgj:elementDescription "Evaluation standards — completeness, clarity, evidence, viability, contribution." ;
+    mgj:elementLabel "Review Criteria" ;
+    mgj:elementType mgj:Bylaw ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/constitution/3>
+    a mgj:ConstitutionalElement ;
+    mgj:elementDescription "Procedural rules — fork, submit PR, review, revise, merge." ;
+    mgj:elementLabel "GitHub Flow" ;
+    mgj:elementType mgj:DecisionProcedure ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/constitution/4>
+    a mgj:ConstitutionalElement ;
+    mgj:elementDescription "Constructive feedback tone, reasonable review timelines, transparency in decision-making." ;
+    mgj:elementLabel "Editorial Norms" ;
+    mgj:elementType mgj:Norm ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/evolution/1>
+    a mgj:EvolutionMechanism ;
+    mgj:mechanismDescription "Anyone can propose changes to framework documents through GitHub issues and pull requests." ;
+    mgj:mechanismLabel "PR-driven amendment" ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/evolution/2>
+    a mgj:EvolutionMechanism ;
+    mgj:mechanismDescription "Editors assess processes and incorporate lessons each quarter." ;
+    mgj:mechanismLabel "Quarterly editorial review" ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/evolution/3>
+    a mgj:EvolutionMechanism ;
+    mgj:mechanismDescription "Framework evolution preserves citation stability via versioned releases." ;
+    mgj:mechanismLabel "Semantic versioning" ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/factor/1>
+    a mgj:EnvironmentalFactor ;
+    mgj:factorDescription "GitHub provides version control, peer-review tooling, and collaboration infrastructure." ;
+    mgj:lessigModality mgj:Architecture ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/factor/2>
+    a mgj:EnvironmentalFactor ;
+    mgj:factorDescription "Inherits scholarly peer-review traditions and open-source GitHub collaboration patterns." ;
+    mgj:lessigModality mgj:Norms ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/factor/3>
+    a mgj:EnvironmentalFactor ;
+    mgj:factorDescription "Functions as a scholarly club good: contribution enables access to curated knowledge." ;
+    mgj:lessigModality mgj:Markets ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/factor/4>
+    a mgj:EnvironmentalFactor ;
+    mgj:factorDescription "Operates under Metagov's nonprofit structure; subject to nonprofit governance regulation." ;
+    mgj:lessigModality mgj:Law ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/fieldsite/1>
+    a mgj:FieldSite ;
+    mgj:fieldSiteDescription "Primary site for submissions, reviews, and discussion." ;
+    mgj:fieldSiteLabel "GitHub repository" ;
+    mgj:fieldSiteURL "https://github.com/metagov/metagov-journal"^^xsd:anyURI ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/fieldsite/2>
+    a mgj:FieldSite ;
+    mgj:fieldSiteDescription "Organizational home and mission context." ;
+    mgj:fieldSiteLabel "Metagov website" ;
+    mgj:fieldSiteURL "https://metagov.org"^^xsd:anyURI ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/fieldsite/3>
+    a mgj:FieldSite ;
+    mgj:fieldSiteDescription "Joshua Tan's introductory articulation of the journal's vision." ;
+    mgj:fieldSiteLabel "Founding blog post" ;
+    mgj:fieldSiteURL "https://journal.metagov.org/2025/08/09/metagov-journal.html"^^xsd:anyURI ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/legal/1>
+    a mgj:LegalContext ;
+    mgj:hostOrganization <https://journal.metagov.org/orgs/metagov> ;
+    mgj:legalContextDescription "The journal operates under Metagov's 501(c)(3) nonprofit infrastructure." ;
+    mgj:legalRelationship mgj:FiscalSponsor ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/origin/1>
+    a mgj:OriginEvent ;
+    mgj:originDate "2024-11-01"^^xsd:date ;
+    mgj:originDescription "In late 2024, Joshua Tan convened Metagov research directors to design a journal for documenting living institutions." ;
+    mgj:originLabel "Founding convening" ;
+    mgj:originParticipant
+        <https://journal.metagov.org/people/ellie-rennie> ,
+        <https://journal.metagov.org/people/joshua-tan> ,
+        <https://journal.metagov.org/people/michael-zargham> ,
+        <https://journal.metagov.org/people/seth-frey> ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/reference/1>
+    a mgj:Reference ;
+    dcterms:creator "Joshua Tan" ;
+    dcterms:date "2025" ;
+    dcterms:identifier "https://journal.metagov.org/2025/08/09/metagov-journal.html" ;
+    dcterms:title "Introducing the Metagov Journal" ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/reference/2>
+    a mgj:Reference ;
+    dcterms:creator
+        "Ilan Ben-Meir" ,
+        "Michael Zargham" ;
+    dcterms:date "2024" ;
+    dcterms:identifier "https://zenodo.org/records/15122312" ;
+    dcterms:title "Protocols and Institutions" ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/reference/3>
+    a mgj:Reference ;
+    dcterms:creator "Michael Zargham" ;
+    dcterms:date "2023" ;
+    dcterms:identifier "https://zenodo.org/records/10609125" ;
+    dcterms:title "What Constitutes a Constitution" ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/reference/4>
+    a mgj:Reference ;
+    dcterms:creator "Jason Potts" ;
+    dcterms:date "2017" ;
+    dcterms:identifier "https://www.tandfonline.com/doi/abs/10.1080/08109028.2017.1386949" ;
+    dcterms:title "A Journal is a Club" ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/1>
+    a mgj:Stakeholder ;
+    mgj:hasRole <https://journal.metagov.org/roles/editor> ;
+    mgj:roleLabel "Editor" ;
+    mgj:stakeholderAgent <https://journal.metagov.org/people/joshua-tan> ;
+    mgj:stakeholderResponsibilities "Lead editor; coordinates review and publication." ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/2>
+    a mgj:Stakeholder ;
+    mgj:hasRole <https://journal.metagov.org/roles/editor> ;
+    mgj:roleLabel "Editor" ;
+    mgj:stakeholderAgent <https://journal.metagov.org/people/michael-zargham> ;
+    mgj:stakeholderResponsibilities "Co-editor; infrastructure and operations." ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/3>
+    a mgj:Stakeholder ;
+    mgj:hasRole <https://journal.metagov.org/roles/research-director> ;
+    mgj:roleLabel "Research Director" ;
+    mgj:stakeholderAgent <https://journal.metagov.org/people/seth-frey> ;
+    mgj:stakeholderResponsibilities "Provides oversight; cognitive-science perspective." ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/4>
+    a mgj:Stakeholder ;
+    mgj:hasRole <https://journal.metagov.org/roles/research-director> ;
+    mgj:roleLabel "Research Director" ;
+    mgj:stakeholderAgent <https://journal.metagov.org/people/ellie-rennie> ;
+    mgj:stakeholderResponsibilities "Provides oversight; digital-ethnography perspective." ;
+.
+
+<https://journal.metagov.org/submissions/metagov-journal/v1.0.0/stakeholder/5>
+    a mgj:Stakeholder ;
+    mgj:hasRole <https://journal.metagov.org/roles/organizational-home> ;
+    mgj:roleLabel "Organizational Home" ;
+    mgj:stakeholderAgent <https://journal.metagov.org/orgs/metagov> ;
+    mgj:stakeholderResponsibilities "Provides nonprofit infrastructure and mission alignment." ;
+.
+
+<https://journal.metagov.org/roles/editor>
+    a skos:Concept ;
+    skos:inScheme mgj:RoleType ;
+    skos:prefLabel "Editor" ;
+.
+
+<https://journal.metagov.org/roles/research-director>
+    a skos:Concept ;
+    skos:inScheme mgj:RoleType ;
+    skos:prefLabel "Research Director" ;
+.

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -1,0 +1,190 @@
+"""M2.5: canonicalization invariants — hash stability, idempotence,
+prefix invariance, and isomorphism-respect."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from rdflib import BNode, Graph, Literal, URIRef
+from rdflib.namespace import RDF
+
+from mgj.canonicalize import (
+    canonical_nt,
+    canonicalize_file,
+    canonicalize_turtle,
+    graph_hash,
+)
+from mgj.models import Institution, Person
+from mgj.namespaces import MGJ
+from mgj.serialize import add_institution, add_person, submission_to_graph
+from tests.test_models import _build_complete_submission
+
+
+# ---------------------------------------------------------------------------
+# Hash stability under triple order / prefix changes
+# ---------------------------------------------------------------------------
+
+
+def _two_graphs_with_same_triples_in_different_orders() -> tuple[Graph, Graph]:
+    EX = "http://ex.org/"
+    triples = [
+        (URIRef(EX + "a"), URIRef(EX + "p"), Literal("x")),
+        (URIRef(EX + "b"), URIRef(EX + "p"), Literal("y")),
+        (URIRef(EX + "a"), URIRef(EX + "q"), Literal("z")),
+    ]
+    g1 = Graph()
+    for t in triples:
+        g1.add(t)
+    g2 = Graph()
+    for t in reversed(triples):
+        g2.add(t)
+    return g1, g2
+
+
+def test_graph_hash_invariant_under_triple_insertion_order() -> None:
+    g1, g2 = _two_graphs_with_same_triples_in_different_orders()
+    assert graph_hash(g1) == graph_hash(g2)
+
+
+def test_graph_hash_changes_on_real_change() -> None:
+    g1, _ = _two_graphs_with_same_triples_in_different_orders()
+    g2 = Graph()
+    for t in g1:
+        g2.add(t)
+    g2.add((URIRef("http://ex.org/c"), URIRef("http://ex.org/p"), Literal("new")))
+    assert graph_hash(g1) != graph_hash(g2)
+
+
+def test_graph_hash_invariant_across_prefix_choice() -> None:
+    """A graph parsed from two different Turtle prefix declarations
+    that produce the same triples must hash equal."""
+    ttl_a = """
+        @prefix ex: <http://ex.org/> .
+        ex:a ex:p "x" ; ex:q "z" .
+        ex:b ex:p "y" .
+    """
+    ttl_b = """
+        @prefix foo: <http://ex.org/> .
+        foo:a foo:p "x" .
+        foo:a foo:q "z" .
+        foo:b foo:p "y" .
+    """
+    g1, g2 = Graph(), Graph()
+    g1.parse(data=ttl_a, format="turtle")
+    g2.parse(data=ttl_b, format="turtle")
+    assert graph_hash(g1) == graph_hash(g2)
+
+
+def test_graph_hash_invariant_across_blank_node_labels() -> None:
+    """Two isomorphic graphs with differently-labeled blank nodes hash equal."""
+    EX = "http://ex.org/"
+    g1 = Graph()
+    b1 = BNode("a")
+    g1.add((URIRef(EX + "x"), URIRef(EX + "has"), b1))
+    g1.add((b1, URIRef(EX + "p"), Literal("v")))
+
+    g2 = Graph()
+    b2 = BNode("zzzz")
+    g2.add((URIRef(EX + "x"), URIRef(EX + "has"), b2))
+    g2.add((b2, URIRef(EX + "p"), Literal("v")))
+
+    assert graph_hash(g1) == graph_hash(g2)
+
+
+# ---------------------------------------------------------------------------
+# canonical_nt and canonicalize_turtle are byte-stable
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_nt_byte_stable() -> None:
+    g1, g2 = _two_graphs_with_same_triples_in_different_orders()
+    assert canonical_nt(g1) == canonical_nt(g2)
+
+
+def test_canonicalize_turtle_byte_stable() -> None:
+    g1, g2 = _two_graphs_with_same_triples_in_different_orders()
+    assert canonicalize_turtle(g1) == canonicalize_turtle(g2)
+
+
+# ---------------------------------------------------------------------------
+# Idempotence: parse → canonicalize → parse → canonicalize is fixed point
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalize_turtle_idempotent_on_submission() -> None:
+    s = _build_complete_submission()
+    institution = Institution(iri=s.institution_iri, name="Test Institution")
+    g = submission_to_graph(s, institution=institution)
+
+    once = canonicalize_turtle(g)
+    g2 = Graph()
+    g2.parse(data=once, format="turtle")
+    twice = canonicalize_turtle(g2)
+    assert once == twice
+
+
+def test_canonicalize_file_idempotent(tmp_path: Path) -> None:
+    """Round-trip a submission through disk canonicalization twice."""
+    s = _build_complete_submission()
+    institution = Institution(iri=s.institution_iri, name="Test Institution")
+    g = submission_to_graph(s, institution=institution)
+
+    p = tmp_path / "instance.ttl"
+    p.write_text(canonicalize_turtle(g))
+
+    # First canonicalize_file: file is already canonical → no change.
+    changed_first = canonicalize_file(p)
+    assert changed_first is False
+
+    # Append the same triples in scrambled order to a fresh file: the
+    # canonicalize_file pass should normalize back to the original.
+    scrambled = """
+        @prefix mgj:     <https://journal.metagov.org/ns/mgj#> .
+        @prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+        @prefix dcterms: <http://purl.org/dc/terms/> .
+        @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+        <https://journal.metagov.org/institutions/test>
+            foaf:name "ignored" .  # extra triple — shouldn't be present after canonicalize
+    """
+    p.write_text(scrambled)
+    canonicalize_file(p)
+    # Now re-canonicalizing should be a fixed point.
+    assert canonicalize_file(p) is False
+
+
+def test_round_trip_hash_preserved_across_disk(tmp_path: Path) -> None:
+    """Hash of an in-memory graph equals hash of the same graph after
+    disk write+reread via canonical Turtle."""
+    s = _build_complete_submission()
+    institution = Institution(iri=s.institution_iri, name="Test Institution")
+    g = submission_to_graph(s, institution=institution)
+
+    p = tmp_path / "instance.ttl"
+    p.write_text(canonicalize_turtle(g))
+
+    g_reloaded = Graph()
+    g_reloaded.parse(str(p), format="turtle")
+
+    assert graph_hash(g) == graph_hash(g_reloaded)
+
+
+# ---------------------------------------------------------------------------
+# Real-world isomorphism: same submission, different IRIs → different hash
+# ---------------------------------------------------------------------------
+
+
+def test_distinct_submissions_have_distinct_hashes() -> None:
+    s1 = _build_complete_submission()
+    s2 = s1.model_copy(
+        update={
+            "submission_version": "1.0.1",
+            "iri": "https://journal.metagov.org/submissions/test/v1.0.1",
+        }
+    )
+    institution = Institution(iri=s1.institution_iri, name="Test Institution")
+    g1 = submission_to_graph(s1, institution=institution)
+    g2 = submission_to_graph(s2, institution=institution)
+    assert graph_hash(g1) != graph_hash(g2)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,287 @@
+"""M3: CLI integration test — drive a complete submission build via
+typer commands and verify it passes system SHACL.
+
+Tests redirect SUBMISSIONS_DIR and SHARED_DIR onto a tmp_path so the
+real repo is not touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import mgj.commands._common as _common
+import mgj.graph as _graph
+from mgj.canonicalize import graph_hash
+from mgj.cli import app
+from mgj.graph import load_instance
+from mgj.validate import validate
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def isolated_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect SUBMISSIONS_DIR and SHARED_DIR onto tmp_path."""
+    submissions = tmp_path / "submissions"
+    shared = tmp_path / "shared"
+    submissions.mkdir()
+    shared.mkdir()
+    monkeypatch.setattr(_graph, "SUBMISSIONS_DIR", submissions)
+    monkeypatch.setattr(_graph, "SHARED_DIR", shared)
+    monkeypatch.setattr(_common, "SUBMISSIONS_DIR", submissions)
+    monkeypatch.setattr(_common, "SHARED_DIR", shared)
+    return tmp_path
+
+
+def _run(args: list[str], expect_success: bool = True) -> object:
+    result = runner.invoke(app, args)
+    if expect_success and result.exit_code != 0:
+        print("OUTPUT:", result.output)
+        print("EXC:", result.exception)
+        raise AssertionError(f"command failed: mgj {' '.join(args)}")
+    return result
+
+
+def test_full_submission_round_trip(isolated_repo: Path) -> None:
+    slug = "test-inst"
+
+    # 1. Seed shared registries.
+    _run(["people", "add", "alice", "--name", "Alice Example"])
+    _run(["people", "add", "bob", "--name", "Bob Example"])
+    _run(["orgs", "add", "metagov", "--name", "Metagov"])
+
+    # 2. Init the submission.
+    _run(["init", slug, "--name", "Test Institution"])
+
+    # 3. Set narratives for each catechism question.
+    for q in range(1, 10):
+        _run(
+            [
+                "narrative",
+                slug,
+                "--question",
+                str(q),
+                f"Narrative for Q{q}.",
+            ]
+        )
+
+    # 4. Q2: a stakeholder.
+    _run(
+        [
+            "stakeholder",
+            "add",
+            slug,
+            "--role-label",
+            "Editor",
+            "--role-slug",
+            "editor",
+            "--person",
+            "alice",
+            "--responsibilities",
+            "Reviews submissions.",
+        ]
+    )
+
+    # 5. Q3: an environmental factor.
+    _run(
+        [
+            "factor",
+            "add",
+            slug,
+            "--modality",
+            "Law",
+            "--description",
+            "Subject to nonprofit regulation.",
+        ]
+    )
+
+    # 6. Q4: a constitutional element.
+    _run(
+        [
+            "constitution",
+            "add",
+            slug,
+            "--label",
+            "Charter",
+            "--description",
+            "Founding charter document.",
+            "--type",
+            "Bylaw",
+        ]
+    )
+
+    # 7. Q5: a field site.
+    _run(
+        [
+            "fieldsite",
+            "add",
+            slug,
+            "--label",
+            "GitHub repo",
+            "--url",
+            "https://github.com/example/repo",
+        ]
+    )
+
+    # 8. Q6: author disclosure.
+    _run(
+        [
+            "author",
+            "set",
+            slug,
+            "--person",
+            "alice",
+            "--role",
+            "founder",
+            "--disclosure",
+            "Author is a founder; potential bias.",
+        ]
+    )
+
+    # 9. Q7: an origin event.
+    _run(
+        [
+            "origin",
+            "add",
+            slug,
+            "--label",
+            "Founding meeting",
+            "--description",
+            "Founders convened.",
+            "--date",
+            "2024-01-01",
+            "--persons",
+            "alice,bob",
+        ]
+    )
+
+    # 10. Q8: an evolution mechanism.
+    _run(
+        [
+            "evolution",
+            "add",
+            slug,
+            "--label",
+            "PR-driven amendment",
+            "--description",
+            "Changes via GitHub PR.",
+        ]
+    )
+
+    # 11. Q9: a reference.
+    _run(
+        [
+            "reference",
+            "add",
+            slug,
+            "--title",
+            "Founding paper",
+            "--identifier",
+            "https://example.org/founding",
+            "--creators",
+            "Alice,Bob",
+            "--date",
+            "2024",
+        ]
+    )
+
+    # 12. Optional: legal context.
+    _run(
+        [
+            "legal",
+            "set",
+            slug,
+            "--host",
+            "metagov",
+            "--relationship",
+            "FiscalSponsor",
+            "--description",
+            "Fiscal sponsorship under Metagov.",
+        ]
+    )
+
+    # 13. System validation should now pass.
+    result = _run(["validate", slug])
+    assert "✓" in result.output, result.output
+
+    # 14. The on-disk instance.ttl loads + passes system SHACL via the
+    # validation library directly (independent of the CLI surface).
+    instance = isolated_repo / "submissions" / slug / "instance.ttl"
+    assert instance.exists()
+    g = load_instance(instance)
+    report = validate(g, mode="system")
+    assert report.conforms, str(report)
+
+
+def test_init_then_validate_fails_until_complete(isolated_repo: Path) -> None:
+    slug = "incomplete"
+    _run(["init", slug, "--name", "Incomplete Institution"])
+    # Bare-bones instance: no narratives, no entities. System validation
+    # should fail.
+    result = runner.invoke(app, ["validate", slug])
+    assert result.exit_code == 1
+    # Run-time assertion that we hit several violations.
+    assert "violation" in result.output.lower() or "FAIL" in result.output
+
+
+def test_canonicalize_idempotent_via_cli(isolated_repo: Path) -> None:
+    slug = "canon"
+    _run(["people", "add", "alice", "--name", "Alice"])
+    _run(["init", slug, "--name", "Canon"])
+    _run(["narrative", slug, "--question", "1", "Purpose."])
+    _run(["stakeholder", "add", slug, "--role-label", "Editor", "--role-slug", "editor", "--person", "alice"])
+
+    instance = isolated_repo / "submissions" / slug / "instance.ttl"
+    before = instance.read_text()
+    _run(["canonicalize", slug])
+    after = instance.read_text()
+    assert before == after  # already canonical because every CLI write canonicalizes
+
+
+def test_stakeholder_add_rejects_unknown_person(isolated_repo: Path) -> None:
+    slug = "rejects"
+    _run(["init", slug, "--name", "Test"])
+    result = runner.invoke(
+        app,
+        [
+            "stakeholder",
+            "add",
+            slug,
+            "--role-label",
+            "Editor",
+            "--role-slug",
+            "editor",
+            "--person",
+            "nonexistent",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_per_question_validation_runs_on_mutation(isolated_repo: Path) -> None:
+    """Adding a malformed entity should be rejected by per-Q SHACL.
+
+    We sneak in a malformed factor by deleting its modality after adding,
+    then running affirm — affirm runs per-Q SHACL and must reject.
+    """
+    slug = "perq"
+    _run(["people", "add", "alice", "--name", "Alice"])
+    _run(["init", slug, "--name", "Test"])
+    _run(["factor", "add", slug, "--modality", "Law", "--description", "ok"])
+    # Manually break the instance.ttl to drop modality, then attempt affirm.
+    from rdflib import Graph
+
+    instance = isolated_repo / "submissions" / slug / "instance.ttl"
+    g = Graph()
+    g.parse(str(instance), format="turtle")
+    from mgj.namespaces import MGJ
+
+    g.remove((None, MGJ.lessigModality, None))
+    instance.write_text(g.serialize(format="turtle"))
+
+    # affirm Q3 should fail per-Q validation.
+    result = runner.invoke(app, ["affirm", slug, "--question", "3"])
+    assert result.exit_code == 1

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,0 +1,296 @@
+"""M4: catechism + wiki compiler tests.
+
+- compiled.md output is byte-stable across runs (determinism invariant)
+- compiled.md includes content from every catechism question
+- wiki produces Home + Institution + Person + Organization pages
+- wiki cross-links resolve (every link target exists as a file)
+- Re-running the wiki compiler is byte-stable
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import mgj.commands._common as _common
+import mgj.graph as _graph
+from mgj.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def isolated_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    submissions = tmp_path / "submissions"
+    shared = tmp_path / "shared"
+    submissions.mkdir()
+    shared.mkdir()
+    monkeypatch.setattr(_graph, "SUBMISSIONS_DIR", submissions)
+    monkeypatch.setattr(_graph, "SHARED_DIR", shared)
+    monkeypatch.setattr(_common, "SUBMISSIONS_DIR", submissions)
+    monkeypatch.setattr(_common, "SHARED_DIR", shared)
+    return tmp_path
+
+
+def _run(args: list[str], expect_success: bool = True) -> object:
+    result = runner.invoke(app, args)
+    if expect_success and result.exit_code != 0:
+        raise AssertionError(f"failed: mgj {' '.join(args)}\n{result.output}")
+    return result
+
+
+def _seed_complete_submission(slug: str) -> None:
+    """Build a complete submission via CLI commands (matches test_cli's fixture)."""
+    _run(["people", "add", "alice", "--name", "Alice Example"])
+    _run(["people", "add", "bob", "--name", "Bob Example"])
+    _run(["orgs", "add", "metagov", "--name", "Metagov"])
+    _run(["init", slug, "--name", "Test Institution", "--date", "2026-04-25"])
+    for q in range(1, 10):
+        _run(
+            ["narrative", slug, "--question", str(q), f"Narrative for Q{q}."]
+        )
+    _run(
+        [
+            "stakeholder",
+            "add",
+            slug,
+            "--role-label",
+            "Editor",
+            "--role-slug",
+            "editor",
+            "--person",
+            "alice",
+            "--responsibilities",
+            "Reviews submissions.",
+        ]
+    )
+    _run(
+        [
+            "factor",
+            "add",
+            slug,
+            "--modality",
+            "Law",
+            "--description",
+            "Subject to nonprofit regulation.",
+        ]
+    )
+    _run(
+        [
+            "constitution",
+            "add",
+            slug,
+            "--label",
+            "Charter",
+            "--description",
+            "Founding charter document.",
+            "--type",
+            "Bylaw",
+        ]
+    )
+    _run(
+        [
+            "fieldsite",
+            "add",
+            slug,
+            "--label",
+            "GitHub repo",
+            "--url",
+            "https://github.com/example/repo",
+        ]
+    )
+    _run(
+        [
+            "author",
+            "set",
+            slug,
+            "--person",
+            "alice",
+            "--role",
+            "founder",
+            "--disclosure",
+            "Author is a founder; potential bias toward favorable framing.",
+        ]
+    )
+    _run(
+        [
+            "origin",
+            "add",
+            slug,
+            "--label",
+            "Founding meeting",
+            "--description",
+            "Founders convened.",
+            "--date",
+            "2024-01-01",
+            "--persons",
+            "alice,bob",
+        ]
+    )
+    _run(
+        [
+            "evolution",
+            "add",
+            slug,
+            "--label",
+            "PR-driven amendment",
+            "--description",
+            "Changes via GitHub PR.",
+        ]
+    )
+    _run(
+        [
+            "reference",
+            "add",
+            slug,
+            "--title",
+            "Founding paper",
+            "--identifier",
+            "https://example.org/founding",
+            "--creators",
+            "Alice,Bob",
+            "--date",
+            "2024",
+        ]
+    )
+    _run(
+        [
+            "legal",
+            "set",
+            slug,
+            "--host",
+            "metagov",
+            "--relationship",
+            "FiscalSponsor",
+            "--description",
+            "Fiscal sponsorship under Metagov.",
+        ]
+    )
+
+
+def test_compile_produces_full_catechism_markdown(isolated_repo: Path) -> None:
+    slug = "demo"
+    _seed_complete_submission(slug)
+
+    _run(["compile", slug])
+    out = isolated_repo / "submissions" / slug / "compiled.md"
+    assert out.exists()
+    body = out.read_text()
+
+    # Header
+    assert "# Test Institution" in body
+    assert "Submission v1.0.0" in body
+
+    # All 9 catechism sections present
+    for q in [
+        "## 1. Purpose",
+        "## 2. Stakeholders",
+        "## 3. Environmental factors",
+        "## 4. Constitution",
+        "## 5. Field sites",
+        "## 6. Author relationship",
+        "## 7. Origins",
+        "## 8. Evolution",
+        "## 9. References",
+    ]:
+        assert q in body, f"missing section: {q}"
+
+    # Legal context section appears (between Q8 and Q9 per the renderer)
+    assert "## Legal context" in body
+    assert "Metagov" in body
+
+    # Stakeholder line
+    assert "**Editor**" in body
+    assert "Alice Example" in body
+
+    # Lessig modality grouping for Q3
+    assert "### Law" in body
+
+    # Reference rendered with link
+    assert "[Founding paper](https://example.org/founding)" in body
+
+
+def test_compile_is_byte_stable(isolated_repo: Path) -> None:
+    """Running the catechism compiler twice over the same instance.ttl
+    produces byte-identical output."""
+    slug = "stable"
+    _seed_complete_submission(slug)
+    _run(["compile", slug])
+    first = (isolated_repo / "submissions" / slug / "compiled.md").read_text()
+    _run(["compile", slug])
+    second = (isolated_repo / "submissions" / slug / "compiled.md").read_text()
+    assert first == second
+
+
+def test_wiki_produces_home_and_entity_pages(isolated_repo: Path) -> None:
+    slug = "wiki-demo"
+    _seed_complete_submission(slug)
+
+    wiki_dir = isolated_repo / "wiki"
+    _run(["wiki", "--output", str(wiki_dir)])
+
+    # Home + Institution + Person × 2 + Organization × 1
+    assert (wiki_dir / "Home.md").exists()
+    assert (wiki_dir / "Institution-test-institution-slug-not-known.md").exists() or any(
+        p.name.startswith("Institution-") for p in wiki_dir.iterdir()
+    )
+    assert (wiki_dir / "Person-alice.md").exists()
+    assert (wiki_dir / "Person-bob.md").exists()
+    assert (wiki_dir / "Organization-metagov.md").exists()
+
+    # Home indexes all institutions and people
+    home = (wiki_dir / "Home.md").read_text()
+    assert "Test Institution" in home
+    assert "Alice Example" in home
+    assert "Metagov" in home
+
+    # Person page has backlinks: alice authored + is a stakeholder + participated in origin
+    alice = (wiki_dir / "Person-alice.md").read_text()
+    assert "Authored submissions" in alice
+    assert "Stakeholder roles" in alice
+    assert "Origin events" in alice
+
+    # Org page records the fiscal sponsor relationship
+    metagov = (wiki_dir / "Organization-metagov.md").read_text()
+    assert "Fiscal Sponsor" in metagov
+    assert "Test Institution" in metagov
+
+
+def test_wiki_is_byte_stable(isolated_repo: Path) -> None:
+    """Re-running the wiki compiler over the same graph state yields identical output."""
+    slug = "wiki-stable"
+    _seed_complete_submission(slug)
+
+    wiki_dir = isolated_repo / "wiki"
+    _run(["wiki", "--output", str(wiki_dir)])
+    first_pages = {
+        p.name: p.read_text() for p in sorted(wiki_dir.iterdir()) if p.suffix == ".md"
+    }
+
+    _run(["wiki", "--output", str(wiki_dir)])
+    second_pages = {
+        p.name: p.read_text() for p in sorted(wiki_dir.iterdir()) if p.suffix == ".md"
+    }
+    assert first_pages == second_pages
+
+
+def test_wiki_internal_links_target_existing_files(isolated_repo: Path) -> None:
+    """Every wiki Markdown link of the form [...](Name) should resolve to
+    a sibling .md file."""
+    slug = "links"
+    _seed_complete_submission(slug)
+    wiki_dir = isolated_repo / "wiki"
+    _run(["wiki", "--output", str(wiki_dir)])
+
+    import re
+
+    page_files = {p.stem for p in wiki_dir.iterdir() if p.suffix == ".md"}
+    for page in wiki_dir.iterdir():
+        if page.suffix != ".md":
+            continue
+        for match in re.finditer(r"\[[^\]]+\]\((Institution|Person|Organization)-[^)]+\)", page.read_text()):
+            link = match.group()
+            target = link.split("](", 1)[1].rstrip(")")
+            assert target in page_files, f"broken link in {page.name}: {target}"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,154 @@
+"""M2: Pydantic model construction and required-field enforcement."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from mgj.models import (
+    ConstitutionalElement,
+    EnvironmentalFactor,
+    EvolutionMechanism,
+    FieldSite,
+    Institution,
+    LegalContext,
+    OriginEvent,
+    Person,
+    Reference,
+    Stakeholder,
+    Submission,
+)
+
+
+def test_person_minimal() -> None:
+    p = Person(iri="https://journal.metagov.org/people/alice", name="Alice")
+    assert p.name == "Alice"
+
+
+def test_person_rejects_empty_name() -> None:
+    with pytest.raises(ValidationError):
+        Person(iri="https://journal.metagov.org/people/x", name="")
+
+
+def test_environmental_factor_modality_literal() -> None:
+    ef = EnvironmentalFactor(
+        iri="https://journal.metagov.org/submissions/x/v1/factor/1",
+        modality="Law",
+        description="Operates under Metagov's 501(c)(3) status.",
+    )
+    assert ef.modality == "Law"
+
+
+def test_environmental_factor_rejects_unknown_modality() -> None:
+    with pytest.raises(ValidationError):
+        EnvironmentalFactor(
+            iri="https://journal.metagov.org/submissions/x/v1/factor/1",
+            modality="Bureaucracy",  # not a Lessig modality
+            description="Some force",
+        )
+
+
+def test_constitutional_element_rejects_unknown_type() -> None:
+    with pytest.raises(ValidationError):
+        ConstitutionalElement(
+            iri="https://journal.metagov.org/submissions/x/v1/constitution/1",
+            label="Charter",
+            description="Founding charter",
+            element_type="Constitution",  # not in our closed scheme
+        )
+
+
+def test_legal_context_rejects_unknown_relationship() -> None:
+    with pytest.raises(ValidationError):
+        LegalContext(
+            iri="https://journal.metagov.org/submissions/x/v1/legal/1",
+            host_organization_iri="https://journal.metagov.org/orgs/metagov",
+            legal_relationship="Affiliate",  # not in closed scheme
+            description="Operates under Metagov.",
+        )
+
+
+def _build_complete_submission() -> Submission:
+    """A minimum-passing submission used by serialize+validate tests."""
+    return Submission(
+        iri="https://journal.metagov.org/submissions/test/v1.0.0",
+        institution_iri="https://journal.metagov.org/institutions/test",
+        submission_date=date(2026, 4, 25),
+        submission_version="1.0.0",
+        author_iri="https://journal.metagov.org/people/alice",
+        author_role="founder",
+        author_disclosure="Author is a founder; potential bias toward favorable framing.",
+        q1_narrative="Purpose narrative.",
+        q2_narrative="Stakeholder narrative.",
+        q3_narrative="Environment narrative.",
+        q4_narrative="Constitution narrative.",
+        q5_narrative="Field site narrative.",
+        q6_narrative="Author relationship narrative.",
+        q7_narrative="Origins narrative.",
+        q8_narrative="Evolution narrative.",
+        q9_narrative="References narrative.",
+        stakeholders=[
+            Stakeholder(
+                iri="https://journal.metagov.org/submissions/test/v1.0.0/stakeholder/1",
+                agent_iri="https://journal.metagov.org/people/alice",
+                role_label="Founder",
+                role_iri="https://journal.metagov.org/roles/founder",
+            )
+        ],
+        environmental_factors=[
+            EnvironmentalFactor(
+                iri="https://journal.metagov.org/submissions/test/v1.0.0/factor/1",
+                modality="Law",
+                description="Subject to nonprofit regulation.",
+            )
+        ],
+        constitutional_elements=[
+            ConstitutionalElement(
+                iri="https://journal.metagov.org/submissions/test/v1.0.0/constitution/1",
+                label="Charter",
+                description="Founding charter document.",
+                element_type="Bylaw",
+            )
+        ],
+        field_sites=[
+            FieldSite(
+                iri="https://journal.metagov.org/submissions/test/v1.0.0/fieldsite/1",
+                label="GitHub repo",
+                url="https://github.com/example/repo",
+            )
+        ],
+        origin_events=[
+            OriginEvent(
+                iri="https://journal.metagov.org/submissions/test/v1.0.0/origin/1",
+                label="Founding meeting",
+                description="Founders convened.",
+                date=date(2024, 1, 1),
+                participant_iris=["https://journal.metagov.org/people/alice"],
+            )
+        ],
+        evolution_mechanisms=[
+            EvolutionMechanism(
+                iri="https://journal.metagov.org/submissions/test/v1.0.0/evolution/1",
+                label="PR-driven amendment",
+                description="Changes via GitHub PR.",
+            )
+        ],
+        references=[
+            Reference(
+                iri="https://journal.metagov.org/submissions/test/v1.0.0/reference/1",
+                title="Founding paper",
+                identifier="https://example.org/founding",
+                creators=["Alice"],
+                date="2024",
+            )
+        ],
+    )
+
+
+def test_complete_submission_constructs() -> None:
+    s = _build_complete_submission()
+    assert len(s.stakeholders) == 1
+    assert s.legal_context is None
+    assert len(s.unresolved_agents) == 0

--- a/tests/test_ontology_parse.py
+++ b/tests/test_ontology_parse.py
@@ -1,0 +1,67 @@
+"""M1 acceptance: ontology and SHACL shape graphs parse, and validating an
+empty instance graph against the system shapes succeeds in returning a
+report (the report is expected to flag missing required fields when given
+an empty graph; the goal here is to confirm pyshacl can load and run the
+shapes against the ontology, not that a degenerate instance passes)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyshacl
+from rdflib import Graph
+
+REPO = Path(__file__).resolve().parents[1]
+ONTOLOGY = REPO / "ontology" / "mgj.ttl"
+SHAPES_DIR = REPO / "ontology" / "shapes"
+PER_QUESTION_DIR = SHAPES_DIR / "per-question"
+SYSTEM_SHAPES = SHAPES_DIR / "system.ttl"
+
+
+def test_ontology_parses() -> None:
+    g = Graph()
+    g.parse(ONTOLOGY, format="turtle")
+    assert len(g) > 0
+
+
+def test_system_shapes_parse() -> None:
+    g = Graph()
+    g.parse(SYSTEM_SHAPES, format="turtle")
+    assert len(g) > 0
+
+
+def test_per_question_shapes_parse() -> None:
+    files = sorted(PER_QUESTION_DIR.glob("q*.ttl"))
+    assert len(files) == 9, f"expected 9 per-question shape files, found {len(files)}"
+    for f in files:
+        g = Graph()
+        g.parse(f, format="turtle")
+        assert len(g) > 0, f"empty graph parsed from {f}"
+
+
+def test_pyshacl_runs_against_empty_instance() -> None:
+    """pyshacl can load shapes + ontology and validate an empty data graph.
+
+    We do not assert validation passes — an empty graph trivially has no
+    targets, so pyshacl should report conforms=True. The point is the
+    machinery loads.
+    """
+    shapes = Graph()
+    shapes.parse(SYSTEM_SHAPES, format="turtle")
+    for f in sorted(PER_QUESTION_DIR.glob("q*.ttl")):
+        shapes.parse(f, format="turtle")
+
+    ontology = Graph()
+    ontology.parse(ONTOLOGY, format="turtle")
+
+    data = Graph()  # empty
+
+    conforms, _report_graph, report_text = pyshacl.validate(
+        data_graph=data,
+        shacl_graph=shapes,
+        ont_graph=ontology,
+        inference="none",
+        meta_shacl=False,
+        advanced=True,
+    )
+    assert conforms is True, f"empty graph should trivially conform; got: {report_text}"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,422 @@
+"""M5: parser orchestration tests using a MockLLMBackend.
+
+We exercise the full pipeline (input.md slicer → backend call →
+RDF emission → reconciliation) without making any network calls.
+"""
+
+from __future__ import annotations
+
+from datetime import date as DateT
+from pathlib import Path
+
+import pytest
+from rdflib import Graph
+from rdflib.namespace import DCTERMS, RDF
+from typer.testing import CliRunner
+
+import mgj.commands._common as _common
+import mgj.commands.extract as extract_cmd
+import mgj.graph as _graph
+from mgj.cli import app
+from mgj.namespaces import MGJ
+from mgj.parser.backends import MockLLMBackend
+from mgj.parser.extract import parse_input_sections, run_extraction
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Section slicing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_input_sections_extracts_each_question() -> None:
+    text = """\
+# Foo
+
+intro
+
+## 1. Purpose
+
+This is Q1 prose.
+
+## 2. Stakeholders
+
+This is Q2 prose.
+
+## 9. References
+
+This is Q9 prose.
+"""
+    sections = parse_input_sections(text)
+    assert set(sections.keys()) == {1, 2, 9}
+    assert "This is Q1 prose." in sections[1]
+    assert "This is Q2 prose." in sections[2]
+    assert "This is Q9 prose." in sections[9]
+
+
+def test_parse_input_sections_returns_empty_for_no_headings() -> None:
+    sections = parse_input_sections("just prose, no headings")
+    assert sections == {}
+
+
+# ---------------------------------------------------------------------------
+# Mock backend dispatch helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_responder_factory():
+    """Returns a responder callable that emits canned per-question JSON
+    based on which Qi the system_prompt is for."""
+
+    def responder(system_prompt: str, user_prompt: str) -> dict:
+        # Each prompt explicitly names its question; key on that.
+        if "Question 2:" in system_prompt:
+            return {
+                "stakeholders": [
+                    {
+                        "role_label": "Editor",
+                        "agent_label": "Alice Chen",
+                        "responsibilities": "Coordinates review.",
+                    },
+                    {
+                        "role_label": "Reader",
+                        "agent_label": "the community",
+                        "responsibilities": None,
+                    },
+                ]
+            }
+        if "Question 3:" in system_prompt:
+            return {
+                "factors": [
+                    {"modality": "Law", "description": "Subject to nonprofit law."}
+                ]
+            }
+        if "Question 4:" in system_prompt:
+            return {
+                "elements": [
+                    {
+                        "label": "Charter",
+                        "description": "Founding document.",
+                        "element_type": "Bylaw",
+                        "source_url": None,
+                    }
+                ]
+            }
+        if "Question 5:" in system_prompt:
+            return {
+                "field_sites": [
+                    {
+                        "label": "GitHub repo",
+                        "url": "https://github.com/example/repo",
+                        "description": None,
+                    }
+                ]
+            }
+        if "Question 6:" in system_prompt:
+            return {
+                "author_label": "Alice Chen",
+                "author_role": "founder",
+                "disclosure": "Author is a founder; potential bias.",
+            }
+        if "Question 7:" in system_prompt:
+            return {
+                "events": [
+                    {
+                        "label": "Founding meeting",
+                        "description": "Founders convened.",
+                        "date": "2024-01-01",
+                        "participant_labels": ["Alice Chen", "Bob Tan"],
+                    }
+                ]
+            }
+        if "Question 8:" in system_prompt:
+            return {
+                "mechanisms": [
+                    {
+                        "label": "PR-driven amendment",
+                        "description": "Changes via GitHub PR.",
+                    }
+                ]
+            }
+        if "Question 9:" in system_prompt:
+            return {
+                "references": [
+                    {
+                        "title": "Founding paper",
+                        "identifier": "https://example.org/founding",
+                        "creators": ["Alice Chen"],
+                        "date": "2024",
+                    }
+                ]
+            }
+        raise RuntimeError(f"unrecognized prompt: {system_prompt[:80]!r}")
+
+    return responder
+
+
+# ---------------------------------------------------------------------------
+# Fixture: isolated repo seeded with init+input.md
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    submissions = tmp_path / "submissions"
+    shared = tmp_path / "shared"
+    submissions.mkdir()
+    shared.mkdir()
+    monkeypatch.setattr(_graph, "SUBMISSIONS_DIR", submissions)
+    monkeypatch.setattr(_graph, "SHARED_DIR", shared)
+    monkeypatch.setattr(_common, "SUBMISSIONS_DIR", submissions)
+    monkeypatch.setattr(_common, "SHARED_DIR", shared)
+    return tmp_path
+
+
+def _seed_with_input(slug: str, repo: Path, prose: str) -> None:
+    runner.invoke(app, ["init", slug, "--name", "Test Institution"])
+    (repo / "submissions" / slug / "input.md").write_text(prose)
+
+
+SAMPLE_PROSE = """\
+# Test Institution
+
+## 1. Purpose
+
+The institution maintains a peer-reviewed commons.
+
+## 2. Stakeholders and roles
+
+Alice Chen is the editor. The community participates as readers.
+
+## 3. Environmental factors
+
+Operates as a nonprofit.
+
+## 4. Constitution
+
+The Charter is the founding document.
+
+## 5. Field sites
+
+GitHub repo at github.com/example/repo.
+
+## 6. Author relationship
+
+I am Alice Chen, founder.
+
+## 7. Origins
+
+Founders convened in early 2024.
+
+## 8. Evolution
+
+Changes happen via PR.
+
+## 9. References
+
+Founding paper at example.org/founding.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Direct API tests (run_extraction)
+# ---------------------------------------------------------------------------
+
+
+def test_run_extraction_emits_typed_entities_via_mock_backend(
+    isolated_repo: Path,
+) -> None:
+    slug = "demo"
+    _seed_with_input(slug, isolated_repo, SAMPLE_PROSE)
+
+    backend = MockLLMBackend(_mock_responder_factory())
+    result = run_extraction(slug, backend=backend)
+
+    assert result.extracted_questions == [2, 3, 4, 5, 6, 7, 8, 9]
+    assert result.cache_misses == [2, 3, 4, 5, 6, 7, 8, 9]
+    assert result.cache_hits == []
+    assert result.skipped_affirmed == []
+
+    # Load the resulting graph and verify entities exist.
+    g = Graph()
+    g.parse(
+        str(isolated_repo / "submissions" / slug / "instance.ttl"),
+        format="turtle",
+    )
+
+    # Q2: 2 stakeholders
+    assert sum(1 for _ in g.subjects(RDF.type, MGJ.Stakeholder)) == 2
+    # Q3: 1 factor, typed Law
+    factors = list(g.subjects(RDF.type, MGJ.EnvironmentalFactor))
+    assert len(factors) == 1
+    assert (factors[0], MGJ.lessigModality, MGJ.Law) in g
+    # Q4: 1 constitutional element typed Bylaw
+    elements = list(g.subjects(RDF.type, MGJ.ConstitutionalElement))
+    assert len(elements) == 1
+    assert (elements[0], MGJ.elementType, MGJ.Bylaw) in g
+    # Q5: 1 fieldsite
+    assert sum(1 for _ in g.subjects(RDF.type, MGJ.FieldSite)) == 1
+    # Q7: 1 origin event with 2 unresolved participants
+    origins = list(g.subjects(RDF.type, MGJ.OriginEvent))
+    assert len(origins) == 1
+    parts = list(g.objects(origins[0], MGJ.originParticipant))
+    assert len(parts) == 2
+    # All participants are UnresolvedAgent (the parser doesn't resolve)
+    for p in parts:
+        assert (p, RDF.type, MGJ.UnresolvedAgent) in g
+    # Q8: 1 evolution mechanism
+    assert sum(1 for _ in g.subjects(RDF.type, MGJ.EvolutionMechanism)) == 1
+    # Q9: 1 reference, with title set
+    refs = list(g.subjects(RDF.type, MGJ.Reference))
+    assert len(refs) == 1
+    titles = list(g.objects(refs[0], DCTERMS.title))
+    assert len(titles) == 1
+    assert str(titles[0]) == "Founding paper"
+
+
+def test_narratives_are_set_for_every_present_section(
+    isolated_repo: Path,
+) -> None:
+    slug = "narratives"
+    _seed_with_input(slug, isolated_repo, SAMPLE_PROSE)
+    backend = MockLLMBackend(_mock_responder_factory())
+    run_extraction(slug, backend=backend)
+
+    g = Graph()
+    g.parse(
+        str(isolated_repo / "submissions" / slug / "instance.ttl"),
+        format="turtle",
+    )
+    sub = next(g.subjects(RDF.type, MGJ.Submission))
+    for q in range(1, 10):
+        prop = MGJ[f"q{q}Narrative"]
+        vals = list(g.objects(sub, prop))
+        assert len(vals) == 1, f"missing narrative for Q{q}"
+
+
+def test_extraction_cache_hits_skip_backend(isolated_repo: Path) -> None:
+    slug = "cache"
+    _seed_with_input(slug, isolated_repo, SAMPLE_PROSE)
+
+    backend = MockLLMBackend(_mock_responder_factory())
+    run_extraction(slug, backend=backend, questions=[2, 3])
+    assert len(backend.calls) == 2
+
+    # Second run with same input should hit cache for both.
+    backend2 = MockLLMBackend(_mock_responder_factory())
+    result = run_extraction(slug, backend=backend2, questions=[2, 3])
+    assert result.cache_hits == [2, 3]
+    assert result.cache_misses == []
+    assert backend2.calls == []  # no backend calls on cache hit
+
+
+def test_affirmed_question_is_skipped_unless_force(
+    isolated_repo: Path,
+) -> None:
+    slug = "affirmed"
+    _seed_with_input(slug, isolated_repo, SAMPLE_PROSE)
+
+    backend = MockLLMBackend(_mock_responder_factory())
+    run_extraction(slug, backend=backend, questions=[2])
+
+    # Affirm Q2 manually via the CLI
+    res = runner.invoke(app, ["affirm", slug, "--question", "2"])
+    assert res.exit_code == 0, res.output
+
+    # Re-run extract Q2: should skip
+    result = run_extraction(slug, backend=backend, questions=[2])
+    assert result.skipped_affirmed == [2]
+    assert result.extracted_questions == []
+
+    # With force=True, it re-extracts.
+    result = run_extraction(slug, backend=backend, questions=[2], force=True)
+    assert result.extracted_questions == [2]
+
+
+def test_reextraction_drops_old_parser_output(isolated_repo: Path) -> None:
+    """Re-running unaffirmed extraction replaces the old parser-output
+    entities for that question, not appends."""
+    slug = "rerun"
+    _seed_with_input(slug, isolated_repo, SAMPLE_PROSE)
+
+    backend = MockLLMBackend(_mock_responder_factory())
+    run_extraction(slug, backend=backend, questions=[2])
+
+    g = Graph()
+    g.parse(str(isolated_repo / "submissions" / slug / "instance.ttl"), format="turtle")
+    first_count = sum(1 for _ in g.subjects(RDF.type, MGJ.Stakeholder))
+    assert first_count == 2
+
+    # Modify input prose so the cache misses; backend returns the same shape
+    # but we should still see the count stay at 2 (replace, not append).
+    new_prose = SAMPLE_PROSE.replace(
+        "Alice Chen is the editor",
+        "Alice Chen is the chief editor",
+    )
+    (isolated_repo / "submissions" / slug / "input.md").write_text(new_prose)
+
+    run_extraction(slug, backend=backend, questions=[2])
+    g = Graph()
+    g.parse(str(isolated_repo / "submissions" / slug / "instance.ttl"), format="turtle")
+    second_count = sum(1 for _ in g.subjects(RDF.type, MGJ.Stakeholder))
+    assert second_count == 2
+
+
+def test_hand_added_entity_is_preserved_on_re_extract(
+    isolated_repo: Path,
+) -> None:
+    """Entities without mgj:extractedBy (hand-added via CLI) survive re-extraction."""
+    slug = "preserve"
+    _seed_with_input(slug, isolated_repo, SAMPLE_PROSE)
+    runner.invoke(app, ["people", "add", "alice", "--name", "Alice"])
+
+    # Hand-add a stakeholder via CLI
+    res = runner.invoke(
+        app,
+        [
+            "stakeholder",
+            "add",
+            slug,
+            "--role-label",
+            "Reviewer",
+            "--role-slug",
+            "reviewer",
+            "--person",
+            "alice",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    backend = MockLLMBackend(_mock_responder_factory())
+    run_extraction(slug, backend=backend, questions=[2])
+
+    g = Graph()
+    g.parse(str(isolated_repo / "submissions" / slug / "instance.ttl"), format="turtle")
+    # We expect: 1 hand-added (no mgj:extractedBy) + 2 from extraction = 3 total
+    total = list(g.subjects(RDF.type, MGJ.Stakeholder))
+    assert len(total) == 3
+    hand_added = [s for s in total if (s, MGJ.extractedBy, None) not in g]
+    assert len(hand_added) == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI command tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_cli_uses_injected_backend(
+    isolated_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    slug = "cli"
+    _seed_with_input(slug, isolated_repo, SAMPLE_PROSE)
+
+    monkeypatch.setattr(
+        extract_cmd,
+        "backend_factory",
+        lambda: MockLLMBackend(_mock_responder_factory()),
+    )
+
+    res = runner.invoke(app, ["extract", slug, "--question", "2"])
+    assert res.exit_code == 0, res.output
+    assert "extracted" in res.output.lower()

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,96 @@
+"""M2: Pydantic Submission → rdflib Graph serialization."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from rdflib import Literal, URIRef
+from rdflib.namespace import FOAF, RDF
+
+from mgj.models import (
+    EnvironmentalFactor,
+    Institution,
+    LegalContext,
+    Organization,
+    Person,
+    Stakeholder,
+    Submission,
+)
+from mgj.namespaces import MGJ
+from mgj.serialize import (
+    add_institution,
+    add_organization,
+    add_person,
+    submission_to_graph,
+)
+from tests.test_models import _build_complete_submission
+
+
+def test_serialize_minimum_submission_round_trips_via_sparql() -> None:
+    s = _build_complete_submission()
+    g = submission_to_graph(s)
+
+    # Submission node has correct rdf:type
+    sub = URIRef(s.iri)
+    assert (sub, RDF.type, MGJ.Submission) in g
+
+    # Per-question narratives present
+    assert (sub, MGJ.q1Narrative, Literal("Purpose narrative.")) in g
+    assert (sub, MGJ.q9Narrative, Literal("References narrative.")) in g
+
+    # Stakeholder edge present
+    sh = URIRef(s.stakeholders[0].iri)
+    assert (sub, MGJ.hasStakeholder, sh) in g
+    assert (sh, RDF.type, MGJ.Stakeholder) in g
+
+    # EnvironmentalFactor typed by Lessig modality
+    ef = URIRef(s.environmental_factors[0].iri)
+    assert (ef, MGJ.lessigModality, MGJ.Law) in g
+
+
+def test_serialize_includes_optional_legal_context() -> None:
+    s = _build_complete_submission()
+    s = s.model_copy(
+        update={
+            "legal_context": LegalContext(
+                iri="https://journal.metagov.org/submissions/test/v1.0.0/legal/1",
+                host_organization_iri="https://journal.metagov.org/orgs/metagov",
+                legal_relationship="FiscalSponsor",
+                description="Fiscal sponsorship under Metagov.",
+                funding_reference="GRANT-2024-1",
+            )
+        }
+    )
+    g = submission_to_graph(s)
+    sub = URIRef(s.iri)
+    lc = URIRef(s.legal_context.iri)
+    assert (sub, MGJ.operatesUnder, lc) in g
+    assert (lc, MGJ.legalRelationship, MGJ.FiscalSponsor) in g
+    assert (lc, MGJ.fundingReference, Literal("GRANT-2024-1")) in g
+
+
+def test_add_person_and_organization_emit_foaf_types() -> None:
+    from rdflib import Graph
+
+    g = Graph()
+    p = Person(iri="https://journal.metagov.org/people/alice", name="Alice Example")
+    o = Organization(iri="https://journal.metagov.org/orgs/metagov", name="Metagov")
+    add_person(g, p)
+    add_organization(g, o)
+    assert (URIRef(p.iri), RDF.type, FOAF.Person) in g
+    assert (URIRef(o.iri), RDF.type, FOAF.Organization) in g
+    assert (URIRef(p.iri), FOAF.name, Literal("Alice Example")) in g
+
+
+def test_add_institution() -> None:
+    from rdflib import Graph
+
+    g = Graph()
+    i = Institution(
+        iri="https://journal.metagov.org/institutions/test",
+        name="Test Institution",
+        description="A test.",
+    )
+    add_institution(g, i)
+    assert (URIRef(i.iri), RDF.type, MGJ.Institution) in g
+    assert (URIRef(i.iri), MGJ.institutionName, Literal("Test Institution")) in g

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,123 @@
+"""M2: SHACL validation runs in per-question and system modes and returns
+structured violations."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import RDF, SKOS
+
+from mgj.models import (
+    Institution,
+    Organization,
+    Person,
+    Stakeholder,
+    Submission,
+)
+from mgj.namespaces import MGJ, role_iri
+from mgj.serialize import (
+    add_institution,
+    add_organization,
+    add_person,
+    submission_to_graph,
+)
+from mgj.validate import validate
+from tests.test_models import _build_complete_submission
+
+
+def _seed_shared(g: Graph) -> None:
+    """Add the shared agents and role concept that the test submission references."""
+    add_person(
+        g,
+        Person(iri="https://journal.metagov.org/people/alice", name="Alice Example"),
+    )
+    # Mint a role concept in mgj:RoleType
+    role = URIRef(role_iri("founder"))
+    g.add((role, RDF.type, SKOS.Concept))
+    g.add((role, SKOS.inScheme, MGJ.RoleType))
+    g.add((role, SKOS.prefLabel, Literal("Founder")))
+
+
+def test_complete_submission_passes_system_shapes() -> None:
+    s = _build_complete_submission()
+    institution = Institution(iri=s.institution_iri, name="Test Institution")
+    g = submission_to_graph(s, institution=institution)
+    _seed_shared(g)
+    report = validate(g, mode="system")
+    assert report.conforms, str(report)
+
+
+def test_missing_q5_fieldsite_fails_system_shapes() -> None:
+    s = _build_complete_submission()
+    s = s.model_copy(update={"field_sites": []})
+    institution = Institution(iri=s.institution_iri, name="Test Institution")
+    g = submission_to_graph(s, institution=institution)
+    _seed_shared(g)
+    report = validate(g, mode="system")
+    assert not report.conforms
+    msgs = " | ".join(v.message for v in report.violations)
+    assert "FieldSite" in msgs
+
+
+def test_missing_q3_factor_fails_system_shapes() -> None:
+    s = _build_complete_submission()
+    s = s.model_copy(update={"environmental_factors": []})
+    institution = Institution(iri=s.institution_iri, name="Test Institution")
+    g = submission_to_graph(s, institution=institution)
+    _seed_shared(g)
+    report = validate(g, mode="system")
+    assert not report.conforms
+    msgs = " | ".join(v.message for v in report.violations)
+    assert "EnvironmentalFactor" in msgs
+
+
+def test_unresolved_agent_fails_system_shapes() -> None:
+    """A stakeholder pointing at an UnresolvedAgent must fail system validation."""
+    s = _build_complete_submission()
+    # Replace the stakeholder's agent with an UnresolvedAgent
+    from mgj.models import UnresolvedAgent
+
+    ua = UnresolvedAgent(
+        iri="https://journal.metagov.org/submissions/test/v1.0.0/unresolved/1",
+        label="the community",
+    )
+    new_stakeholder = s.stakeholders[0].model_copy(update={"agent_iri": ua.iri})
+    s = s.model_copy(
+        update={
+            "stakeholders": [new_stakeholder],
+            "unresolved_agents": [ua],
+        }
+    )
+    institution = Institution(iri=s.institution_iri, name="Test Institution")
+    g = submission_to_graph(s, institution=institution)
+    _seed_shared(g)
+    report = validate(g, mode="system")
+    assert not report.conforms
+    msgs = " | ".join(v.message for v in report.violations)
+    assert "UnresolvedAgent" in msgs or "resolved" in msgs
+
+
+def test_per_question_q3_well_formedness_passes() -> None:
+    """An EnvironmentalFactor with a valid modality passes the Q3 inner-loop shape."""
+    s = _build_complete_submission()
+    institution = Institution(iri=s.institution_iri, name="Test Institution")
+    g = submission_to_graph(s, institution=institution)
+    _seed_shared(g)
+    report = validate(g, mode="per_question", question=3)
+    assert report.conforms, str(report)
+
+
+def test_per_question_q3_rejects_factor_without_modality() -> None:
+    """An EnvironmentalFactor with no Lessig modality fails Q3 inner-loop validation."""
+    s = _build_complete_submission()
+    institution = Institution(iri=s.institution_iri, name="Test Institution")
+    g = submission_to_graph(s, institution=institution)
+    _seed_shared(g)
+    # Drop the lessigModality triple from the (one) EnvironmentalFactor
+    factor_iri = URIRef(s.environmental_factors[0].iri)
+    g.remove((factor_iri, MGJ.lessigModality, None))
+    report = validate(g, mode="per_question", question=3)
+    assert not report.conforms
+    msgs = " | ".join(v.message for v in report.violations)
+    assert "Lessig" in msgs or "lessigModality" in msgs.lower() or "modality" in msgs

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,18 @@
+# Metagov Journal
+
+<!-- compiler: mgj.compilers.wiki v0.1.0 -->
+
+## Institutions
+
+- [The Metagov Journal](Institution-metagov-journal)
+
+## People
+
+- [Ellie Rennie](Person-ellie-rennie)
+- [Joshua Tan](Person-joshua-tan)
+- [Michael Zargham](Person-michael-zargham)
+- [Seth Frey](Person-seth-frey)
+
+## Organizations
+
+- [Metagov](Organization-metagov)

--- a/wiki/Institution-metagov-journal.md
+++ b/wiki/Institution-metagov-journal.md
@@ -1,0 +1,103 @@
+# The Metagov Journal
+
+*Submission v1.0.0 — 2026-04-25*
+
+<!-- compiler: mgj.compilers.catechism v0.1.0 -->
+
+## 1. Purpose
+
+The Metagov Journal produces and maintains a peer-reviewed commons of institutional knowledge. Its stable pattern involves practitioners documenting living institutions through structured catechisms, peers reviewing these documentations for completeness and clarity, and the community accumulating reusable organizational patterns. Success manifests as a growing repository of institutional specifications that practitioners reference when designing new organizations or evolving existing ones. The institution functions properly when submissions flow regularly, reviews maintain quality standards, and documented patterns get reused across contexts.
+
+## 2. Stakeholders and roles
+
+Authors document institutions they understand deeply, answering the catechism and providing supporting materials. Reviewers evaluate submissions for completeness, clarity, and contribution to knowledge. Editors (initially Joshua Tan as lead, with Michael Zargham) coordinate review processes, make publication decisions, and maintain infrastructure. Readers access documented patterns for learning and adaptation. Metagov provides organizational home and alignment with digital self-governance mission, with research directors Seth Frey and Ellie Rennie providing oversight.
+
+### Stakeholders
+
+- **Editor**: Joshua Tan — Lead editor; coordinates review and publication.
+- **Editor**: Michael Zargham — Co-editor; infrastructure and operations.
+- **Research Director**: Seth Frey — Provides oversight; cognitive-science perspective.
+- **Research Director**: Ellie Rennie — Provides oversight; digital-ethnography perspective.
+- **Organizational Home**: Metagov — Provides nonprofit infrastructure and mission alignment.
+
+## 3. Environmental factors
+
+The journal operates within overlapping contexts. Technically, it depends on GitHub for version control and collaboration, technical platforms for archival storage and DOIs. Academically, it bridges scholarly publishing conventions with open-source software practices. Legally, it operates under Metagov's nonprofit structure. Normatively, it inherits from both peer review traditions and GitHub collaboration patterns. Economically, it functions as a scholarly club good where contribution enables access to curated knowledge.
+
+### Law
+
+- Operates under Metagov's nonprofit structure; subject to nonprofit governance regulation.
+
+### Norms
+
+- Inherits scholarly peer-review traditions and open-source GitHub collaboration patterns.
+
+### Markets
+
+- Functions as a scholarly club good: contribution enables access to curated knowledge.
+
+### Architecture
+
+- GitHub provides version control, peer-review tooling, and collaboration infrastructure.
+
+## 4. Constitution
+
+The foundational rules emerge from three layers. The Catechism (nine questions) structures all submissions, creating comparable documentation. The Review Criteria define evaluation standards — completeness, clarity, evidence, viability, and contribution. The GitHub Flow establishes procedural rules — fork, submit PR, review, revise, merge.
+
+### Bylaw
+
+- **Catechism**: Nine-question framework that structures every submission, creating comparable documentation.
+- **Review Criteria**: Evaluation standards — completeness, clarity, evidence, viability, contribution.
+
+### Norm
+
+- **Editorial Norms**: Constructive feedback tone, reasonable review timelines, transparency in decision-making.
+
+### Decision Procedure
+
+- **GitHub Flow**: Procedural rules — fork, submit PR, review, revise, merge.
+
+## 5. Field sites
+
+Primary activity occurs at github.com/metagov/journal — submissions, reviews, and discussions. The Metagov website offers organizational context. Joshua Tan's introductory blog post articulates the founding vision.
+
+- [GitHub repository](https://github.com/metagov/metagov-journal) — Primary site for submissions, reviews, and discussion.
+- [Metagov website](https://metagov.org) — Organizational home and mission context.
+- [Founding blog post](https://journal.metagov.org/2025/08/09/metagov-journal.html) — Joshua Tan's introductory articulation of the journal's vision.
+
+## 6. Author relationship
+
+As author of this draft, I am a systems engineer and protocol architect with deep experience in open source communities — my role in Metagov is often to map systems and provide operational policy recommendations. Joshua Tan, Metagov co-founder and journal's primary driver, provides vision and organizational support. We both serve on Metagov's board, creating alignment but also potential conflicts of interest.
+
+*Authored by **Michael Zargham** — co-editor and board member.*
+
+*Disclosure:* Author serves on Metagov's board with Joshua Tan; potential conflict of interest. Bootstrap submission receives review from fellow research directors rather than external reviewers. Blind spots likely include overemphasis on technical mechanisms.
+
+## 7. Origins
+
+The journal emerged from Joshua Tan's observation that governance experiments in DAOs, cooperatives, and digital communities generate valuable innovations but lack documentation venues. In late 2024, Tan convened Metagov research directors to design a solution. The founding team brought complementary perspectives: Tan (platform governance), Zargham (systems engineering), Frey (cognitive science), Rennie (digital ethnography).
+
+- **Founding convening** (2024-11-01): In late 2024, Joshua Tan convened Metagov research directors to design a journal for documenting living institutions. — *participants: Ellie Rennie, Joshua Tan, Michael Zargham, Seth Frey*
+
+## 8. Evolution
+
+Evolution operates through multiple mechanisms. Immediate adaptation happens via GitHub. Periodic review occurs quarterly as editors assess processes and incorporate lessons. Version control enables framework evolution while maintaining citation stability through semantic versioning. Community feedback shapes development through discussions and reviews. Scaling triggers activate new processes as volume grows.
+
+- **PR-driven amendment**: Anyone can propose changes to framework documents through GitHub issues and pull requests.
+- **Quarterly editorial review**: Editors assess processes and incorporate lessons each quarter.
+- **Semantic versioning**: Framework evolution preserves citation stability via versioned releases.
+
+## Legal context
+
+*Operates under **Metagov** as fiscal sponsor.*
+
+The journal operates under Metagov's 501(c)(3) nonprofit infrastructure.
+
+## 9. References
+
+Foundational documents and academic references that ground the journal's design and motivate its operating model.
+
+1. Joshua Tan (2025). [Introducing the Metagov Journal](https://journal.metagov.org/2025/08/09/metagov-journal.html)
+2. Ilan Ben-Meir, Michael Zargham (2024). [Protocols and Institutions](https://zenodo.org/records/15122312)
+3. Michael Zargham (2023). [What Constitutes a Constitution](https://zenodo.org/records/10609125)
+4. Jason Potts (2017). [A Journal is a Club](https://www.tandfonline.com/doi/abs/10.1080/08109028.2017.1386949)

--- a/wiki/Organization-metagov.md
+++ b/wiki/Organization-metagov.md
@@ -1,0 +1,13 @@
+# Metagov
+
+<!-- compiler: mgj.compilers.wiki v0.1.0 -->
+
+`https://journal.metagov.org/orgs/metagov`
+
+## Hosts
+
+- Fiscal Sponsor of [The Metagov Journal](Institution-metagov-journal)
+
+## Stakeholder roles
+
+- **Organizational Home** in [The Metagov Journal](Institution-metagov-journal)

--- a/wiki/Person-ellie-rennie.md
+++ b/wiki/Person-ellie-rennie.md
@@ -1,0 +1,13 @@
+# Ellie Rennie
+
+<!-- compiler: mgj.compilers.wiki v0.1.0 -->
+
+`https://journal.metagov.org/people/ellie-rennie`
+
+## Stakeholder roles
+
+- **Research Director** in [The Metagov Journal](Institution-metagov-journal)
+
+## Origin events
+
+- **Founding convening** (2024-11-01) — [The Metagov Journal](Institution-metagov-journal)

--- a/wiki/Person-joshua-tan.md
+++ b/wiki/Person-joshua-tan.md
@@ -1,0 +1,13 @@
+# Joshua Tan
+
+<!-- compiler: mgj.compilers.wiki v0.1.0 -->
+
+`https://journal.metagov.org/people/joshua-tan`
+
+## Stakeholder roles
+
+- **Editor** in [The Metagov Journal](Institution-metagov-journal)
+
+## Origin events
+
+- **Founding convening** (2024-11-01) — [The Metagov Journal](Institution-metagov-journal)

--- a/wiki/Person-michael-zargham.md
+++ b/wiki/Person-michael-zargham.md
@@ -1,0 +1,17 @@
+# Michael Zargham
+
+<!-- compiler: mgj.compilers.wiki v0.1.0 -->
+
+`https://journal.metagov.org/people/michael-zargham`
+
+## Authored submissions
+
+- [The Metagov Journal](Institution-metagov-journal)
+
+## Stakeholder roles
+
+- **Editor** in [The Metagov Journal](Institution-metagov-journal)
+
+## Origin events
+
+- **Founding convening** (2024-11-01) — [The Metagov Journal](Institution-metagov-journal)

--- a/wiki/Person-seth-frey.md
+++ b/wiki/Person-seth-frey.md
@@ -1,0 +1,13 @@
+# Seth Frey
+
+<!-- compiler: mgj.compilers.wiki v0.1.0 -->
+
+`https://journal.metagov.org/people/seth-frey`
+
+## Stakeholder roles
+
+- **Research Director** in [The Metagov Journal](Institution-metagov-journal)
+
+## Origin events
+
+- **Founding convening** (2024-11-01) — [The Metagov Journal](Institution-metagov-journal)


### PR DESCRIPTION
## Summary

Introduces an RDF-native authoring, validation, and publishing pipeline for the journal, following the *ask → ingest → conform → confirm → compile* loop:

- Authors write prose; an LLM-driven parser extracts typed RDF triples; an interactive CLI walks the author through Q-by-Q confirmation; deterministic compilers produce the published Markdown article and a cross-linked wiki.
- The typed RDF graph (`instance.ttl`) is the canonical source of truth. Compiled Markdown and wiki pages are derived artifacts, regenerated by CI on every push to `main`.
- Authors never edit Turtle directly — every mutation flows through `mgj` CLI commands that load → mutate → SHACL-validate → canonicalize → save atomically.

Built incrementally across 8 milestones; full plan in `/Users/z/.claude/plans/i-want-to-create-compiled-reddy.md`.

## What's new

**Schema layer** — `ontology/mgj.ttl` defines the 9-question catechism as typed entities (Submission, Institution, Stakeholder, EnvironmentalFactor, ConstitutionalElement, FieldSite, OriginEvent, EvolutionMechanism, Reference) plus a cross-question `LegalContext` for the host/sponsor relationship. SKOS schemes for Lessig modalities, constitutional element types, and an open RoleType vocabulary. PROV-O extension for parser provenance.

**Validation** — `ontology/shapes/per-question/q{1..9}-*.ttl` for inner-loop checks; `system.ttl` for outer-loop cardinality + integrity + no-`UnresolvedAgent` rule. `mgj validate <slug> [-q N]` runs either profile.

**Canonicalization** — URDNA2015 + sorted N-Triples → SHA-256 content hash. `longturtle` over the canonical graph for stable on-disk Turtle. Every CLI write canonicalizes; git diffs reflect only meaningful triple changes.

**CLI** — entity CRUD per Qi, lifecycle, shared registries, affirmation, compilation, wiki generation, LLM extraction. Provider-agnostic backend interface (`LLMBackend` Protocol → `ClaudeBackend` default + `MockLLMBackend` for tests; OpenAI/Gemini/local backends drop in by implementing the same interface).

**Compilers** — deterministic SPARQL-driven Markdown rendering for both the per-submission article and a cross-linked wiki (Home + Institution + Person + Organization pages with backlinks).

**CI** — `validate.yml` runs SHACL + tests + a staleness check; `compile.yml` recompiles + regenerates the wiki + bot-commits artifacts back to `main`.

**Self-submission migrated** — `submissions/metagov-journal/` now contains `input.md` (author prose), `instance.ttl` (261 lines of canonical Turtle), `compiled.md` (regenerated article), and `extraction-trace.json`. Built end-to-end via `scripts/build_self_submission.py`. The legacy `manifest.yml` + `specification.md` are intentionally left in place; can retire in a follow-up.

## Commits

1. `21f04f6` add mgj ontology, SHACL shapes, and core Python layer
2. `88b55ef` add CLI, compilers, and provider-agnostic LLM extraction parser
3. `301883c` add validate and compile CI workflows
4. `ce6a1b2` migrate metagov-journal self-submission to RDF pipeline

## Test plan

- [x] `pytest -v` — 50 tests passing (ontology parse, SHACL validation, model round-trips, canonicalization invariants, CLI integration, compiler determinism, wiki cross-linking, parser orchestration with mock backend, caching, affirmation gating, re-extraction reconciliation)
- [x] `python scripts/build_self_submission.py` runs cleanly and reproduces the self-submission end-to-end
- [x] `mgj validate metagov-journal` reports `✓ system`
- [x] `mgj compile metagov-journal` and `mgj wiki` produce byte-stable output across re-runs (CI staleness check passes)
- [x] Once merged, `compile.yml` should fire on the merge-to-main push and verify the bot-commit path works

## Open questions for review

- Should `submissions/metagov-journal/specification.md` and `manifest.yml` be removed now that `input.md`/`instance.ttl`/`compiled.md` are canonical, or kept until v1.1.0 cuts a tag?
- The `wiki/` files are committed for the staleness check to work; alternative is to gitignore them and have `compile.yml` push to a dedicated `*.wiki` repo. Worth a follow-up.
- Per-question prompts (`src/mgj/parser/prompts.py`) are stable inputs to the prompt cache — every edit invalidates cache for previously-extracted submissions. May want to version-pin them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)