### PR TITLE
Publish auto-generated wiki to GitHub Wiki

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -49,3 +49,48 @@ jobs:
           else
             echo "no changes to commit"
           fi
+
+      - name: Publish wiki/ to GitHub Wiki
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          WIKI_DIR=".wiki-tmp"
+          WIKI_URL="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.wiki.git"
+          rm -rf "$WIKI_DIR"
+
+          # Existing wiki (>=1 commit) is clonable; a freshly-enabled wiki
+          # with no pages may not yet have a clonable .wiki.git endpoint —
+          # in that case we initialize a fresh local repo and let the
+          # first push create the remote branch.
+          if git clone --depth 1 "$WIKI_URL" "$WIKI_DIR" 2>/dev/null; then
+            echo "cloned existing wiki"
+            # Remove only auto-published pages so any hand-edited
+            # _Sidebar.md / _Footer.md / custom page is preserved.
+            find "$WIKI_DIR" -maxdepth 1 -type f \
+              \( -name "Home.md" \
+              -o -name "Institution-*.md" \
+              -o -name "Person-*.md" \
+              -o -name "Organization-*.md" \) -delete
+          else
+            echo "wiki has no commits yet; initializing local repo"
+            mkdir -p "$WIKI_DIR"
+            git -C "$WIKI_DIR" init -q -b master
+            git -C "$WIKI_DIR" remote add origin "$WIKI_URL"
+          fi
+
+          cp wiki/*.md "$WIKI_DIR/"
+
+          cd "$WIKI_DIR"
+          git config user.name "metagov-journal-bot"
+          git config user.email "bot@metagov.org"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "no wiki changes to publish"
+            exit 0
+          fi
+          git commit -q -m "auto-publish wiki from $SHA"
+          git push -q -u origin HEAD:master


### PR DESCRIPTION
## Summary

Now that the repo is public and Wikis are enabled, the `compile.yml` workflow can push the auto-generated `wiki/*.md` pages into the actual GitHub Wiki for `metagov/metagov-journal`. Adds a single step at the end of `compile.yml` that runs after the regular compile + commit pass on every push to `main`.

## What it does

The new "Publish wiki/ to GitHub Wiki" step:

- Clones `metagov-journal.wiki.git` if any pages have been published, or initializes a fresh local repo if the wiki is brand-new (the remote isn't clonable until first commit lands).
- Removes only the auto-published page set (`Home.md`, `Institution-*.md`, `Person-*.md`, `Organization-*.md`) so any hand-edited pages like `_Sidebar.md` / `_Footer.md` survive.
- Copies the freshly-regenerated `wiki/*.md` files in, commits, pushes to `master` (the wiki repo's default branch).
- Idempotent: a no-change run exits cleanly.

Uses the default `GITHUB_TOKEN` (no PAT required) since the workflow already has `permissions: contents: write`, which covers wiki access on the same repo.

## What it does NOT do

- The committed `wiki/` directory in the main repo is preserved as a backup / file-browseable view. The GitHub Wiki becomes the canonical navigable presentation. We can drop the committed copy in a follow-up if it ends up being redundant.
- No CI workflow runs on this PR (validate.yml triggers on push, and a feature branch behaves the same as before).

## Test plan

- [x] YAML parses and the new step is the 7th step of the `compile` job.
- [x] `pytest -v` — all 50 tests still pass (workflow change is CI-only, no Python touched).
- [x] After merge: confirm `compile.yml` succeeds on the merge-to-main push and that `github.com/metagov/metagov-journal/wiki` populates with the 7 expected pages. (This is the actual integration test for the change.)

## Closes

- #2 — wiki publishing was blocked on org-level Wiki support; making the repo public + enabling the Wiki feature has resolved the blocker, and this PR wires the publishing step. After merge, refer to the post-merge run for confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)