### PR TITLE
Add wiki engagement docs (Read / Submit / Review / Contribute)

### DIFF
--- a/src/mgj/compilers/wiki.py
+++ b/src/mgj/compilers/wiki.py
@@ -136,6 +136,23 @@ def _render_home(g: Graph) -> str:
     lines.append(f"<!-- compiler: {WIKI_COMPILER_ID} v{WIKI_COMPILER_VERSION} -->")
     lines.append("")
 
+    # Engagement section — links to the hand-authored pages that describe
+    # how readers, authors, reviewers, and contributors participate. Page
+    # files (Reading.md, Submitting.md, Reviewing.md, Contributing.md) are
+    # checked into wiki/ in the repo and published alongside the auto-
+    # generated catalog.
+    lines.extend(
+        [
+            "## How to engage",
+            "",
+            "- [Reading the journal](Reading) — discover and read institutional specifications",
+            "- [Submitting a specification](Submitting) — author and submit a new specification",
+            "- [Participating in review](Reviewing) — peer-review open submissions",
+            "- [Contributing to the framework](Contributing) — evolve the catechism, criteria, and tools",
+            "",
+        ]
+    )
+
     institutions = _institution_index(g)
     lines.append("## Institutions")
     lines.append("")

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,0 +1,29 @@
+# Contributing to the Framework
+
+The journal itself is a living institution — its catechism, evaluation criteria, ontology, and tooling all evolve through the same GitHub-native workflow used for submissions.
+
+## Three modes of contribution
+
+- **Open an [issue](https://github.com/metagov/metagov-journal/issues)** for proposals, gaps, bugs, or questions about the framework. Issues are the right home for "the catechism doesn't account for X" or "the SHACL shape is too strict about Y."
+
+- **Open a PR against framework files**:
+  - `catechism.md` — the nine questions
+  - `criteria.md`, `evaluation.md` — review standards
+  - `ontology/mgj.ttl`, `ontology/shapes/**` — the schema
+  - `src/mgj/**` — CLI, parser, compilers
+  - `scripts/**` — operational scripts
+
+  Framework PRs follow the same review process as submissions: comment, iterate, merge.
+
+- **Discuss** in the PR thread. Substantive framework changes warrant editorial review and may benefit from broader notice; tag editors when relevant.
+
+## What's a "framework" change vs. a "submission" change?
+
+- A *submission* change touches files only in `submissions/{slug}/` and `shared/` (when adding new people/orgs). It documents an institution.
+- A *framework* change touches root-level docs, the ontology, the SHACL shapes, the CLI, or the workflows. It changes how all submissions are written, validated, or published.
+
+The same tooling reviews both — the difference is intent and scope.
+
+## Versioning
+
+The framework follows semantic versioning. Backward-incompatible changes to the catechism or ontology (e.g., adding a required entity type) bump the major version. Submissions are pinned to the version of the framework they were written against.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -2,6 +2,13 @@
 
 <!-- compiler: mgj.compilers.wiki v0.1.0 -->
 
+## How to engage
+
+- [Reading the journal](Reading) — discover and read institutional specifications
+- [Submitting a specification](Submitting) — author and submit a new specification
+- [Participating in review](Reviewing) — peer-review open submissions
+- [Contributing to the framework](Contributing) — evolve the catechism, criteria, and tools
+
 ## Institutions
 
 - [The Metagov Journal](Institution-metagov-journal)

--- a/wiki/Reading.md
+++ b/wiki/Reading.md
@@ -1,0 +1,19 @@
+# Reading the Journal
+
+The journal publishes structured specifications of *living institutions* — organizations that demonstrate active participation, capacity for adaptation, and observable patterns of collective behavior.
+
+## Where to find institutions
+
+- **This wiki** is the navigable entry point. The [Home](Home) page lists every institution, person, and organization currently in the catalog. Click any **Institution** page for the full specification rendered as an article. **Person** and **Organization** pages list everyone they're affiliated with — useful for tracing who-does-what across institutions.
+
+- **The repository** holds the source of truth at [github.com/metagov/metagov-journal](https://github.com/metagov/metagov-journal). Each institution lives at `submissions/{slug}/` with three artifacts:
+  - `input.md` — the author's prose answering the catechism
+  - `instance.ttl` — the canonical RDF graph (Turtle) — the structured truth
+  - `compiled.md` — the published article view, regenerated from `instance.ttl` by CI
+
+- **For programmatic access**, the RDF in `instance.ttl` plus `shared/people.ttl` and `shared/organizations.ttl` can be queried with SPARQL or any RDF tool. The schema lives at `ontology/mgj.ttl`.
+
+## What to read first
+
+- The [catechism](https://github.com/metagov/metagov-journal/blob/main/catechism.md) — the nine questions every submission answers. Reading it makes every submission much easier to navigate.
+- The [self-referential submission](Institution-metagov-journal) — the journal documents itself as the inaugural specification, demonstrating the pattern.

--- a/wiki/Reviewing.md
+++ b/wiki/Reviewing.md
@@ -1,0 +1,21 @@
+# Participating in Review
+
+Anyone can review an open submission. Review happens entirely on GitHub via the standard pull-request flow.
+
+## Find an open submission
+
+Open the [pull requests page](https://github.com/metagov/metagov-journal/pulls). Submissions in review are PRs whose head branch starts with `submit/`. Each PR's "Files changed" tab shows the new submission directory: `submissions/{slug}/input.md`, `instance.ttl`, and `compiled.md`.
+
+## How to review
+
+1. **Read `compiled.md` first** — it's the article view the journal will publish. If it reads coherently and the institution is recognizable as *living*, the substance is probably sound.
+2. **Cross-check `input.md`** — the author's source prose. The compiled view is generated from the structured RDF, but `input.md` carries the voice and reflexivity (especially Q6).
+3. **Skim `instance.ttl`** — the RDF Turtle is the canonical structure. You don't have to grok it line-by-line; spot-check that the entities (stakeholders, references, etc.) match what the prose claims.
+4. **Apply the criteria** in [criteria.md](https://github.com/metagov/metagov-journal/blob/main/criteria.md). For a structured framework (severity per question, common pitfalls), see [evaluation.md](https://github.com/metagov/metagov-journal/blob/main/evaluation.md).
+5. **Comment** using GitHub's inline review or the "Review changes" feature. Suggest specific revisions; quote the catechism when relevant.
+
+Editors decide when a submission is ready to merge. Multiple rounds of revision are normal and expected.
+
+## What you don't have to do
+
+You don't need to run the CLI to review — `validate.yml` already SHACL-validates every PR and the staleness check confirms `compiled.md` matches `instance.ttl`. Your job is editorial judgment, not mechanical verification.

--- a/wiki/Submitting.md
+++ b/wiki/Submitting.md
@@ -1,0 +1,22 @@
+# Submitting a Specification
+
+Submissions are GitHub pull requests. Authors fork the repository, build their submission with the `mgj` CLI, and open a PR; reviewers comment, the author iterates, editors merge.
+
+## Workflow
+
+1. **Fork** [metagov/metagov-journal](https://github.com/metagov/metagov-journal) and clone your fork.
+2. **Read** the [catechism](https://github.com/metagov/metagov-journal/blob/main/catechism.md) and the [evaluation criteria](https://github.com/metagov/metagov-journal/blob/main/criteria.md).
+3. **Branch**: `git checkout -b submit/{your-institution-slug}`.
+4. **Install the CLI**: `pip install -e .` from the repo root. This makes `mgj` available.
+5. **Scaffold**: `mgj init {your-slug} --name "Your Institution"`. This creates `submissions/{your-slug}/` with an `input.md` template.
+6. **Author** your `input.md` against the catechism — 75–110 words per question, concrete examples, references where possible.
+7. **Build the structured graph**:
+    - With LLM extraction: `mgj extract {your-slug}` parses your prose into typed RDF.
+    - Or hand-build via CLI commands (`mgj stakeholder add`, `mgj factor add`, etc.) — see `mgj --help` and the [build script](https://github.com/metagov/metagov-journal/blob/main/scripts/build_self_submission.py) as a worked example.
+8. **Validate**: `mgj validate {your-slug}` — must pass before review.
+9. **Compile**: `mgj compile {your-slug}` writes `compiled.md`. Read it; if it doesn't read naturally, return to step 6 or 7.
+10. **Open a PR** against `main`. The `validate.yml` workflow re-runs all checks. Reviewers comment in the PR thread.
+
+## What the editors look for
+
+The [evaluation criteria](https://github.com/metagov/metagov-journal/blob/main/criteria.md) are the formal standard. Briefly: completeness across all nine catechism answers, clarity, evidence (references resolve), demonstrated "living" status, and contribution to the broader catalog.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,16 @@
+# Metagov Journal
+
+**[Home](Home)** — index of submissions
+
+### How to engage
+
+- [Reading](Reading)
+- [Submitting](Submitting)
+- [Reviewing](Reviewing)
+- [Contributing](Contributing)
+
+### Reference
+
+- [Catechism](https://github.com/metagov/metagov-journal/blob/main/catechism.md)
+- [Evaluation criteria](https://github.com/metagov/metagov-journal/blob/main/criteria.md)
+- [Reviewer framework](https://github.com/metagov/metagov-journal/blob/main/evaluation.md)


### PR DESCRIPTION
## Summary

Surfaces the four modes of journal engagement on the wiki — reading, submitting, reviewing, contributing — as short, action-oriented entry-point pages that link into the existing canonical docs (`catechism.md`, `criteria.md`, `evaluation.md`, etc.) rather than duplicating them.

## What's added

- **[wiki/Reading.md](wiki/Reading.md)** — how to discover and read institutional specifications. Covers the wiki entry point, the repo's `submissions/` directory, and the RDF source for programmatic queries.
- **[wiki/Submitting.md](wiki/Submitting.md)** — the new RDF-native author workflow: fork → branch → `mgj init` → write `input.md` → `mgj extract` (or hand-build via CLI) → `mgj validate` → `mgj compile` → PR. Cites the [build_self_submission.py](scripts/build_self_submission.py) script as a worked example.
- **[wiki/Reviewing.md](wiki/Reviewing.md)** — peer review on open PRs using GitHub-native review tools, plus the order of artifacts to read (`compiled.md` → `input.md` → spot-check `instance.ttl`) and pointers to the criteria + reviewer-framework docs.
- **[wiki/Contributing.md](wiki/Contributing.md)** — evolving the framework itself via issues + PRs, with a clear distinction between *submission* changes (institutions) and *framework* changes (catechism, ontology, CLI).
- **[wiki/_Sidebar.md](wiki/_Sidebar.md)** — persistent navigation across all wiki pages.

## Compiler change

Modifies `src/mgj/compilers/wiki.py:_render_home` to render a "How to engage" section above the institution catalog on `Home.md`. The added lines are static (don't depend on graph state), so wiki output stays byte-stable for fixed `(instance.ttl, compiler_version)` pairs — determinism invariant preserved.

## Why hand-authored, not auto-generated?

The engagement docs describe the *workflow*, not the *data*. They're stable across submissions and don't derive from the RDF graph, so they don't belong in the auto-generated set. Living in `wiki/` in this repo means they're version-controlled, reviewable via PR, and the compile.yml publish step's selective delete (only `Home.md`, `Institution-*.md`, `Person-*.md`, `Organization-*.md`) preserves them while still letting the canonical version in this repo win on push.

## Test plan

- [x] `pytest -v` — 50 tests still passing. The wiki determinism test in `test_compile.py` continues to hold because the new "How to engage" lines are static.
- [x] `mgj wiki` regenerates `Home.md` with the engagement section above the catalog (verified locally).
- [x] After merge: confirm the four new pages render at https://github.com/metagov/metagov-journal/wiki/Reading (etc.) and that `_Sidebar.md` shows up as the persistent left nav on every page.

## Follow-up flagged

The new wiki pages describe the **new** RDF-native pipeline (`mgj` CLI, `input.md` / `instance.ttl` / `compiled.md`), but the root-level [`contributing.md`](contributing.md) and [`implementation.md`](implementation.md) still describe the legacy `manifest.yml` + `specification.md` workflow. Those should be updated in a separate PR — this PR intentionally doesn't touch them since the wiki is the user-visible entry point and unblocking it shouldn't be gated on a content rewrite of the root docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)