### PR TITLE
Add @mzargham as default code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# GitHub CODEOWNERS for the Metagov Journal
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# @mzargham is the lead editor and is automatically requested for review on
+# every PR by default. As the editorial group expands, refine the patterns
+# below (e.g. submissions/* could route to specific submission authors;
+# ontology/ could route to the framework maintainers).
+
+* @mzargham


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` so every PR auto-requests review from @mzargham as the lead editor.

```
* @mzargham
```

The leading comment notes that as the editorial group expands, the pattern can be refined — e.g. `submissions/*` could route to specific submission authors, `ontology/` to framework maintainers, etc.

## Test plan

- [ ] After merge: open a test PR and confirm GitHub auto-requests review from @mzargham.
- [ ] Existing open PRs (#5, #6) won't get auto-routed retroactively, but that's fine — they're already author-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)