### PR TITLE
Add Infrastructure Contributor as a fifth distinct mode of engagement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,9 +38,23 @@ To participate in peer review:
 ## For Readers
 
 To understand the framework:
+
 - [Background](./background.md) - intellectual foundations
 - [Catechism](./catechism.md) - core documentation framework
 - [Implementation](./implementation.md) - how the journal operates
+
+## For Infrastructure Contributors
+
+The schema, tooling, and AI-facilitation layer that processes every submission are themselves open to contribution — distinct from authoring or reviewing. Surfaces include the OWL ontology, SHACL shapes, the `mgj` CLI, the serialization/deserialization layer, the compilers, the parser prompts, and the CI workflows.
+
+To contribute infrastructure:
+
+1. Open an [issue](https://github.com/metagov/metagov-journal/issues) describing the gap, proposal, or bug
+2. Fork, branch, make your change with tests where applicable
+3. Open a PR — code owners review per [`.github/CODEOWNERS`](./.github/CODEOWNERS)
+4. See the wiki's [Contributing](https://github.com/metagov/metagov-journal/wiki/Contributing) page for the full surface inventory and review expectations
+
+Note: changes to the catechism, criteria, or evaluation docs are *framework* changes (different from infrastructure changes) and warrant editorial-group review beyond code-owner approval.
 
 ## Repository Structure
 

--- a/src/mgj/compilers/wiki.py
+++ b/src/mgj/compilers/wiki.py
@@ -148,7 +148,7 @@ def _render_home(g: Graph) -> str:
             "- [Reading the journal](Reading) — discover and read institutional specifications",
             "- [Submitting a specification](Submitting) — author and submit a new specification",
             "- [Participating in review](Reviewing) — peer-review open submissions",
-            "- [Contributing to the framework](Contributing) — evolve the catechism, criteria, and tools",
+            "- [Contributing to infrastructure](Contributing) — improve the schema, CLI, parser, compilers, and CI that everyone depends on",
             "",
         ]
     )

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,29 +1,42 @@
-# Contributing to the Framework
+# Contributing to Infrastructure
 
-The journal itself is a living institution — its catechism, evaluation criteria, ontology, and tooling all evolve through the same GitHub-native workflow used for submissions.
+Infrastructure contributions evolve the journal's machinery itself — the typed schema, the tooling, and the AI facilitation that every author and reviewer depends on. This is a **distinct mode of participation** from authoring submissions, peer-reviewing them, or serving as an editor: infrastructure contributions improve how *every* submission gets processed, not the substance of any single submission.
 
-## Three modes of contribution
+## What counts as infrastructure
 
-- **Open an [issue](https://github.com/metagov/metagov-journal/issues)** for proposals, gaps, bugs, or questions about the framework. Issues are the right home for "the catechism doesn't account for X" or "the SHACL shape is too strict about Y."
+| Surface | What it does |
+| --- | --- |
+| `ontology/mgj.ttl` | OWL classes defining the catechism schema |
+| `ontology/shapes/**` | SHACL shapes gating validation (per-question + system) |
+| `src/mgj/models.py`, `serialize.py` | Pydantic ↔ RDF serialization / deserialization |
+| `src/mgj/cli.py`, `src/mgj/commands/**` | The `mgj` command-line interface |
+| `src/mgj/compilers/**` | Deterministic compilation: `instance.ttl` → `compiled.md` and the wiki |
+| `src/mgj/parser/**` | LLM-assisted catechism extraction — the **AI facilitation layer** |
+| `src/mgj/parser/prompts.py` | The prompt templates that shape extraction behavior |
+| `.github/workflows/**` | CI: validate, compile, publish the wiki |
+| `scripts/**` | Operational scripts (e.g. self-submission rebuild) |
 
-- **Open a PR against framework files**:
-  - `catechism.md` — the nine questions
-  - `criteria.md`, `evaluation.md` — review standards
-  - `ontology/mgj.ttl`, `ontology/shapes/**` — the schema
-  - `src/mgj/**` — CLI, parser, compilers
-  - `scripts/**` — operational scripts
+## How to contribute
 
-  Framework PRs follow the same review process as submissions: comment, iterate, merge.
+1. **Open an [issue](https://github.com/metagov/metagov-journal/issues)** describing the gap, proposal, or bug. For non-trivial proposals, discuss in the issue before writing code.
+2. **Fork the repo and branch** off `main`.
+3. **Make your change.** For ontology / SHACL changes, ensure existing submissions still validate. For CLI / parser changes, add or update tests in `tests/`. For workflow changes, describe what triggers and what side effects.
+4. **Open a PR.** `validate.yml` runs `pytest`, SHACL system validation on every submission, and a compile-staleness check.
+5. **Code owners review** per [`.github/CODEOWNERS`](https://github.com/metagov/metagov-journal/blob/main/.github/CODEOWNERS). Reviewers check correctness, scope, backwards compatibility (does this break existing submissions?), and alignment with the journal's design principles.
+6. **Merge.** Once approved and CI is green, merge to `main` triggers `compile.yml`, which recompiles every `compiled.md` and republishes the wiki.
 
-- **Discuss** in the PR thread. Substantive framework changes warrant editorial review and may benefit from broader notice; tag editors when relevant.
+## Framework changes vs. infrastructure changes
 
-## What's a "framework" change vs. a "submission" change?
+A note on scope: changes to [`catechism.md`](https://github.com/metagov/metagov-journal/blob/main/catechism.md), [`criteria.md`](https://github.com/metagov/metagov-journal/blob/main/criteria.md), or [`evaluation.md`](https://github.com/metagov/metagov-journal/blob/main/evaluation.md) are **framework changes**, not infrastructure changes. They alter what every author must answer or how reviewers evaluate; they warrant **editorial group review** beyond code-owner approval. If you're proposing a catechism question change or a new evaluation criterion, expect a longer discussion.
 
-- A *submission* change touches files only in `submissions/{slug}/` and `shared/` (when adding new people/orgs). It documents an institution.
-- A *framework* change touches root-level docs, the ontology, the SHACL shapes, the CLI, or the workflows. It changes how all submissions are written, validated, or published.
+## How this fits with the other modes
 
-The same tooling reviews both — the difference is intent and scope.
+| Role | What they do |
+| --- | --- |
+| **Reader** | Browses the wiki and repo to learn from documented institutions |
+| **Author** | Documents an institution they participate in, answering the catechism |
+| **Reviewer** | Peer-reviews open submissions on substance |
+| **Editor** | Coordinates review, makes publication decisions (appointed) |
+| **Infrastructure contributor** | Improves the schema, tooling, and AI facilitation that everyone else depends on (open — anyone can contribute) |
 
-## Versioning
-
-The framework follows semantic versioning. Backward-incompatible changes to the catechism or ontology (e.g., adding a required entity type) bump the major version. Submissions are pinned to the version of the framework they were written against.
+Recurring substantive infrastructure contributors may be invited into the editorial group over time, but contributing infrastructure doesn't require editorial appointment.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -7,7 +7,7 @@
 - [Reading the journal](Reading) — discover and read institutional specifications
 - [Submitting a specification](Submitting) — author and submit a new specification
 - [Participating in review](Reviewing) — peer-review open submissions
-- [Contributing to the framework](Contributing) — evolve the catechism, criteria, and tools
+- [Contributing to infrastructure](Contributing) — improve the schema, CLI, parser, compilers, and CI that everyone depends on
 
 ## Institutions
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -2,14 +2,14 @@
 
 **[Home](Home)** — index of submissions
 
-### How to engage
+## How to engage
 
-- [Reading](Reading)
-- [Submitting](Submitting)
-- [Reviewing](Reviewing)
-- [Contributing](Contributing)
+- [Reading](Reading) — readers
+- [Submitting](Submitting) — authors
+- [Reviewing](Reviewing) — peer reviewers
+- [Contributing](Contributing) — infrastructure
 
-### Reference
+## Reference
 
 - [Catechism](https://github.com/metagov/metagov-journal/blob/main/catechism.md)
 - [Evaluation criteria](https://github.com/metagov/metagov-journal/blob/main/criteria.md)


### PR DESCRIPTION
## Summary

Per author direction, **infrastructure contribution** is a distinct mode of participation alongside reading, authoring, peer-reviewing, and editing. It covers the codebase that processes every submission:

- the OWL ontology and SHACL shapes
- Pydantic ↔ RDF serialization / deserialization
- the `mgj` CLI
- the deterministic compilers (`compiled.md` + wiki)
- the **AI facilitation layer** (parser + prompts)
- the CI workflows

This mode is open — no editorial appointment required. It flows through GitHub-native issue + PR + code-owner review.

## What this PR changes

### `wiki/Contributing.md` — rewritten
Now titled **"Contributing to Infrastructure"** with:

- An explicit surface inventory (table mapping each directory to what it does — `ontology/`, `src/mgj/{models,serialize,cli,commands,compilers,parser}`, `.github/workflows/`, `scripts/`)
- A 6-step workflow (issue → fork → change → PR → code-owner review → merge)
- A clear distinction between **framework changes** (`catechism.md`, `criteria.md`, `evaluation.md` — warrant editorial-group review beyond code-owner approval) and **infrastructure changes** (everything else)
- A comparison table covering all 5 modes (Reader, Author, Reviewer, Editor, Infrastructure Contributor) so the distinctions are explicit

### `wiki/_Sidebar.md`
Each engagement link is now annotated with the audience it serves (readers / authors / peer reviewers / infrastructure). Heading levels bumped from h3 to h2 to fix a pre-existing lint warning.

### `src/mgj/compilers/wiki.py`
The auto-generated `Home.md` "How to engage" link for Contributing now reads "Contributing to infrastructure — improve the schema, CLI, parser, compilers, and CI that everyone depends on" instead of the previous catch-all "framework" framing.

### `readme.md`
New **"For Infrastructure Contributors"** section after "For Readers". Concise (under 150 words) — surfaces the contribution surfaces, the 4-step workflow, and points to the wiki Contributing page for the full picture. Also explicitly notes the framework-vs-infrastructure distinction.

## What's still on the follow-up list

- Rewrite `contributing.md` and `implementation.md` for the new RDF-native pipeline (still describe the legacy `manifest.yml`/`specification.md` workflow)
- Decide what to do with legacy `manifest.yml` + `specification.md` in `submissions/metagov-journal/`
- Add OpenMBEE / Dynamical Systems Group entries to the journal's Q9 references

## Test plan

- [x] `pytest -v` — 50 tests still passing
- [x] `mgj wiki` regenerates 10 pages cleanly
- [x] Determinism preserved (the new Home line is static text, not graph-derived)
- [ ] After merge: confirm wiki/Contributing renders the new infrastructure-focused page; confirm Home + Sidebar show the audience annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)